### PR TITLE
Add `resetChildrenWhenVesselDestroyed` parameter to `VesselParameterGroup`

### DIFF
--- a/source/ContractConfigurator/ParameterFactory/VesselParameterGroupFactory.cs
+++ b/source/ContractConfigurator/ParameterFactory/VesselParameterGroupFactory.cs
@@ -21,6 +21,7 @@ namespace ContractConfigurator
         protected bool dissassociateVesselsOnContractFailure;
         protected bool dissassociateVesselsOnContractCompletion;
         protected bool hideVesselName;
+        protected bool resetChildrenWhenVesselDestroyed;
 
         public IEnumerable<string> Vessel { get { return vesselList.Select<VesselIdentifier, string>(vi => vi.identifier); } }
 
@@ -36,13 +37,15 @@ namespace ContractConfigurator
             valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "dissassociateVesselsOnContractFailure", x => dissassociateVesselsOnContractFailure = x, this, true);
             valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "dissassociateVesselsOnContractCompletion", x => dissassociateVesselsOnContractCompletion = x, this, false);
             valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "hideVesselName", x => hideVesselName = x, this, false);
+            valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "resetChildrenWhenVesselDestroyed", x => resetChildrenWhenVesselDestroyed = x, this, false);
 
             return valid;
         }
 
         public override ContractParameter Generate(Contract contract)
         {
-            return new Parameters.VesselParameterGroup(title, define, defineList, Vessel, duration.Value, dissassociateVesselsOnContractFailure, dissassociateVesselsOnContractCompletion, hideVesselName);
+            return new Parameters.VesselParameterGroup(title, define, defineList, Vessel, duration.Value,
+                dissassociateVesselsOnContractFailure, dissassociateVesselsOnContractCompletion, hideVesselName, resetChildrenWhenVesselDestroyed);
         }
     }
 }


### PR DESCRIPTION
Use when contract uses vessel assignment in a way where one VPG assigns the vessel and 1 or more other VPGs in the same contract consume it. This fixes the issue where when the vessel got destroyed the contract stays permalocked on a vessel that no longer even exists.