### PR TITLE
Fix HasCrew misbehaving inside a VPG

### DIFF
--- a/source/ContractConfigurator/Parameter/ParameterDelegate.cs
+++ b/source/ContractConfigurator/Parameter/ParameterDelegate.cs
@@ -503,22 +503,26 @@ namespace ContractConfigurator.Parameters
             int count = GetCount(values, dest);
             LoggingUtil.LogVerbose(this, "Count = {0}", count);
             bool countConditionMet = (count >= minCount && count <= maxCount);
+
+            ParameterState newState;
+            if (countConditionMet)
+            {
+                newState = ParameterState.Complete;
+            }
+            // Something before us failed, so we're uncertain
+            else if (!conditionMet && ignorePreviousFailures)
+            {
+                newState = ParameterState.Incomplete;
+            }
+            else
+            {
+                newState = ParameterState.Failed;
+                conditionMet = false;
+            }
+
             if (!checkOnly)
             {
-                if (countConditionMet)
-                {
-                    SetState(ParameterState.Complete);
-                }
-                // Something before us failed, so we're uncertain
-                else if (!conditionMet && ignorePreviousFailures)
-                {
-                    SetState(ParameterState.Incomplete);
-                }
-                else
-                {
-                    SetState(ParameterState.Failed);
-                    conditionMet = false;
-                }
+                SetState(newState);
             }
         }
     }


### PR DESCRIPTION
This would allow us to surround HasCrew parameters with VPGs and thus avoid issues when switching vessels.