### PR TITLE
Remove all unnecessary new EventData<T>.OnEvent and new EventVoid.OnEvent calls

### DIFF
--- a/source/CC_RemoteTech/RemoteTechParameter.cs
+++ b/source/CC_RemoteTech/RemoteTechParameter.cs
@@ -20,13 +20,13 @@ namespace ContractConfigurator.RemoteTech
         protected override void OnRegister()
         {
             base.OnRegister();
-            RemoteTechAssistant.OnRemoteTechUpdate.Add(new EventData<VesselSatellite>.OnEvent(OnRemoteTechUpdate));
+            RemoteTechAssistant.OnRemoteTechUpdate.Add(OnRemoteTechUpdate);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            RemoteTechAssistant.OnRemoteTechUpdate.Remove(new EventData<VesselSatellite>.OnEvent(OnRemoteTechUpdate));
+            RemoteTechAssistant.OnRemoteTechUpdate.Remove(OnRemoteTechUpdate);
         }
 
         protected void OnRemoteTechUpdate(VesselSatellite s)

--- a/source/CC_RemoteTech/RemoteTechProgressTracker.cs
+++ b/source/CC_RemoteTech/RemoteTechProgressTracker.cs
@@ -189,12 +189,12 @@ namespace ContractConfigurator.RemoteTech
 
         public void Start()
         {
-            RemoteTechAssistant.OnRemoteTechUpdate.Add(new EventData<VesselSatellite>.OnEvent(OnRemoteTechUpdate));
+            RemoteTechAssistant.OnRemoteTechUpdate.Add(OnRemoteTechUpdate);
         }
 
         public void OnDestroy()
         {
-            RemoteTechAssistant.OnRemoteTechUpdate.Remove(new EventData<VesselSatellite>.OnEvent(OnRemoteTechUpdate));
+            RemoteTechAssistant.OnRemoteTechUpdate.Remove(OnRemoteTechUpdate);
         }
 
         void FixedUpdate()

--- a/source/CC_RemoteTech/VesselConnectivityParameter.cs
+++ b/source/CC_RemoteTech/VesselConnectivityParameter.cs
@@ -67,15 +67,15 @@ namespace ContractConfigurator.RemoteTech
         protected override void OnRegister()
         {
             base.OnRegister();
-            ContractVesselTracker.OnVesselAssociation.Add(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselAssociation));
-            ContractVesselTracker.OnVesselDisassociation.Add(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselDisassociation));
+            ContractVesselTracker.OnVesselAssociation.Add(OnVesselAssociation);
+            ContractVesselTracker.OnVesselDisassociation.Add(OnVesselDisassociation);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            ContractVesselTracker.OnVesselAssociation.Remove(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselAssociation));
-            ContractVesselTracker.OnVesselDisassociation.Remove(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselDisassociation));
+            ContractVesselTracker.OnVesselAssociation.Remove(OnVesselAssociation);
+            ContractVesselTracker.OnVesselDisassociation.Remove(OnVesselDisassociation);
         }
 
         protected void OnVesselAssociation(GameEvents.HostTargetAction<Vessel, string> hta)

--- a/source/ContractConfigurator/Behaviour/DialogBox.cs
+++ b/source/ContractConfigurator/Behaviour/DialogBox.cs
@@ -824,12 +824,12 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnRegister()
         {
-            GameEvents.onFlightReady.Add(new EventVoid.OnEvent(OnFlightReady));
+            GameEvents.onFlightReady.Add(OnFlightReady);
         }
 
         protected override void OnUnregister()
         {
-            GameEvents.onFlightReady.Remove(new EventVoid.OnEvent(OnFlightReady));
+            GameEvents.onFlightReady.Remove(OnFlightReady);
         }
 
         protected void OnFlightReady()

--- a/source/ContractConfigurator/Behaviour/ExperimentalPart.cs
+++ b/source/ContractConfigurator/Behaviour/ExperimentalPart.cs
@@ -53,15 +53,15 @@ namespace ContractConfigurator.Behaviour
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onParameterChange.Add(OnParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onParameterChange.Remove(OnParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnParameterChange);
         }
         
         protected override void OnAccepted()

--- a/source/ContractConfigurator/Behaviour/PartTestHandler.cs
+++ b/source/ContractConfigurator/Behaviour/PartTestHandler.cs
@@ -25,16 +25,16 @@ namespace ContractConfigurator.Behaviour
         {
             base.OnRegister();
 
-            GameEvents.onVesselChange.Add(new EventData<Vessel>.OnEvent(OnVesselChange));
-            GameEvents.onFlightReady.Add(new EventVoid.OnEvent(OnFlightReady));
+            GameEvents.onVesselChange.Add(OnVesselChange);
+            GameEvents.onFlightReady.Add(OnFlightReady);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
 
-            GameEvents.onVesselChange.Remove(new EventData<Vessel>.OnEvent(OnVesselChange));
-            GameEvents.onFlightReady.Remove(new EventVoid.OnEvent(OnFlightReady));
+            GameEvents.onVesselChange.Remove(OnVesselChange);
+            GameEvents.onFlightReady.Remove(OnFlightReady);
         }
 
         private void OnFlightReady()

--- a/source/ContractConfigurator/Behaviour/SpawnKerbal.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnKerbal.cs
@@ -392,12 +392,12 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnRegister()
         {
-            GameEvents.onVesselRecovered.Add(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
+            GameEvents.onVesselRecovered.Add(OnVesselRecovered);
         }
 
         protected override void OnUnregister()
         {
-            GameEvents.onVesselRecovered.Remove(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
+            GameEvents.onVesselRecovered.Remove(OnVesselRecovered);
         }
 
         private void OnVesselRecovered(ProtoVessel v, bool quick)

--- a/source/ContractConfigurator/Behaviour/SpawnPassengers.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnPassengers.cs
@@ -48,8 +48,8 @@ namespace ContractConfigurator.Behaviour
 
             protected void Start()
             {
-                GameEvents.onHideUI.Add(new EventVoid.OnEvent(OnHideUI));
-                GameEvents.onShowUI.Add(new EventVoid.OnEvent(OnShowUI));
+                GameEvents.onHideUI.Add(OnHideUI);
+                GameEvents.onShowUI.Add(OnShowUI);
             }
 
             protected void OnDestroy()
@@ -233,14 +233,14 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnRegister()
         {
-            GameEvents.onVesselRecovered.Add(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
-            GameEvents.onFlightReady.Add(new EventVoid.OnEvent(OnFlightReady));
+            GameEvents.onVesselRecovered.Add(OnVesselRecovered);
+            GameEvents.onFlightReady.Add(OnFlightReady);
         }
 
         protected override void OnUnregister()
         {
-            GameEvents.onVesselRecovered.Remove(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
-            GameEvents.onFlightReady.Remove(new EventVoid.OnEvent(OnFlightReady));
+            GameEvents.onVesselRecovered.Remove(OnVesselRecovered);
+            GameEvents.onFlightReady.Remove(OnFlightReady);
         }
 
         protected void OnFlightReady()

--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -723,14 +723,14 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnRegister()
         {
-            GameEvents.onVesselRecovered.Add(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
-            GameEvents.onGameSceneLoadRequested.Add(new EventData<GameScenes>.OnEvent(OnGameSceneLoad));
+            GameEvents.onVesselRecovered.Add(OnVesselRecovered);
+            GameEvents.onGameSceneLoadRequested.Add(OnGameSceneLoad);
         }
 
         protected override void OnUnregister()
         {
-            GameEvents.onVesselRecovered.Remove(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
-            GameEvents.onGameSceneLoadRequested.Remove(new EventData<GameScenes>.OnEvent(OnGameSceneLoad));
+            GameEvents.onVesselRecovered.Remove(OnVesselRecovered);
+            GameEvents.onGameSceneLoadRequested.Remove(OnGameSceneLoad);
         }
 
         private void OnVesselRecovered(ProtoVessel v, bool quick)

--- a/source/ContractConfigurator/Behaviour/WaypointGenerator.cs
+++ b/source/ContractConfigurator/Behaviour/WaypointGenerator.cs
@@ -96,7 +96,7 @@ namespace ContractConfigurator.Behaviour
 
         public WaypointGenerator()
         {
-            GameEvents.OnMapViewFiltersModified.Add(new EventData<MapViewFiltering.VesselTypeFilter>.OnEvent(OnMapViewFiltersModified));
+            GameEvents.OnMapViewFiltersModified.Add(OnMapViewFiltersModified);
         }
 
         /// <summary>
@@ -512,14 +512,14 @@ namespace ContractConfigurator.Behaviour
         {
             base.OnRegister();
 
-            GameEvents.onFlightReady.Add(new EventVoid.OnEvent(OnFlightReady));
+            GameEvents.onFlightReady.Add(OnFlightReady);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
 
-            GameEvents.onFlightReady.Remove(new EventVoid.OnEvent(OnFlightReady));
+            GameEvents.onFlightReady.Remove(OnFlightReady);
 
             foreach (WaypointData wpData in waypoints)
             {

--- a/source/ContractConfigurator/ConfiguredContract.cs
+++ b/source/ContractConfigurator/ConfiguredContract.cs
@@ -830,27 +830,27 @@ namespace ContractConfigurator
         protected override void OnRegister()
         {
             base.OnRegister();
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterStateChange));
+            ContractConfigurator.OnParameterChange.Add(OnParameterStateChange);
             foreach (ContractBehaviour behaviour in behaviours)
             {
                 behaviour.Register();
             }
 
-            GameEvents.onVesselChange.Add(new EventData<Vessel>.OnEvent(OnVesselChange));
-            OnStateChange.Add(new EventData<State>.OnEvent(SelfStateChanged));
+            GameEvents.onVesselChange.Add(OnVesselChange);
+            OnStateChange.Add(SelfStateChanged);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterStateChange));
+            ContractConfigurator.OnParameterChange.Remove(OnParameterStateChange);
             foreach (ContractBehaviour behaviour in behaviours)
             {
                 behaviour.Unregister();
             }
 
-            GameEvents.onVesselChange.Remove(new EventData<Vessel>.OnEvent(OnVesselChange));
-            OnStateChange.Remove(new EventData<State>.OnEvent(SelfStateChanged));
+            GameEvents.onVesselChange.Remove(OnVesselChange);
+            OnStateChange.Remove(SelfStateChanged);
         }
 
         protected override void OnUpdate()

--- a/source/ContractConfigurator/CutScene/CutSceneExecutor.cs
+++ b/source/ContractConfigurator/CutScene/CutSceneExecutor.cs
@@ -45,12 +45,12 @@ namespace ContractConfigurator.CutScene
 
         public void Start()
         {
-            GameEvents.onGameSceneSwitchRequested.Add(new EventData<GameEvents.FromToAction<GameScenes, GameScenes>>.OnEvent(GameSceneSwitch));
+            GameEvents.onGameSceneSwitchRequested.Add(GameSceneSwitch);
         }
 
         public void OnDestroy()
         {
-            GameEvents.onGameSceneSwitchRequested.Remove(new EventData<GameEvents.FromToAction<GameScenes, GameScenes>>.OnEvent(GameSceneSwitch));
+            GameEvents.onGameSceneSwitchRequested.Remove(GameSceneSwitch);
             if (state != State.IDLE)
             {
                 EnableInputs();

--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -322,9 +322,9 @@ namespace ContractConfigurator.Util
                 ticks = 0;
 
                 // Disable GameEvent handlers
-                GameEvents.Contract.onOffered.Remove(new EventData<Contract>.OnEvent(OnContractOffered));
-                GameEvents.Contract.onDeclined.Remove(new EventData<Contract>.OnEvent(OnContractDeclined));
-                GameEvents.Contract.onFinished.Remove(new EventData<Contract>.OnEvent(OnContractFinished));
+                GameEvents.Contract.onOffered.Remove(OnContractOffered);
+                GameEvents.Contract.onDeclined.Remove(OnContractDeclined);
+                GameEvents.Contract.onFinished.Remove(OnContractFinished);
 
                 return;
             }
@@ -405,9 +405,9 @@ namespace ContractConfigurator.Util
                 GameEvents.Contract.onContractsListChanged = new EventVoid("onContractsListChanged");
 
                 // Contract state change handlers
-                GameEvents.Contract.onOffered.Add(new EventData<Contract>.OnEvent(OnContractOffered));
-                GameEvents.Contract.onDeclined.Add(new EventData<Contract>.OnEvent(OnContractDeclined));
-                GameEvents.Contract.onFinished.Add(new EventData<Contract>.OnEvent(OnContractFinished));
+                GameEvents.Contract.onOffered.Add(OnContractOffered);
+                GameEvents.Contract.onDeclined.Add(OnContractDeclined);
+                GameEvents.Contract.onFinished.Add(OnContractFinished);
             }
 
             if (ticks == 1 || ticks == 2)

--- a/source/ContractConfigurator/Parameter/All.cs
+++ b/source/ContractConfigurator/Parameter/All.cs
@@ -66,15 +66,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Add(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnAnyContractParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Remove(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnAnyContractParameterChange);
         }
 
         protected void OnAnyContractParameterChange(Contract contract, ContractParameter contractParameter)

--- a/source/ContractConfigurator/Parameter/Any.cs
+++ b/source/ContractConfigurator/Parameter/Any.cs
@@ -65,15 +65,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Add(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnAnyContractParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Remove(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnAnyContractParameterChange);
         }
 
         protected void OnAnyContractParameterChange(Contract contract, ContractParameter contractParameter)

--- a/source/ContractConfigurator/Parameter/AtLeast.cs
+++ b/source/ContractConfigurator/Parameter/AtLeast.cs
@@ -65,15 +65,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Add(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnAnyContractParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Remove(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnAnyContractParameterChange);
         }
 
         protected void OnAnyContractParameterChange(Contract contract, ContractParameter contractParameter)

--- a/source/ContractConfigurator/Parameter/AtMost.cs
+++ b/source/ContractConfigurator/Parameter/AtMost.cs
@@ -65,15 +65,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Add(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnAnyContractParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Remove(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnAnyContractParameterChange);
         }
 
         protected void OnAnyContractParameterChange(Contract contract, ContractParameter contractParameter)

--- a/source/ContractConfigurator/Parameter/Duration.cs
+++ b/source/ContractConfigurator/Parameter/Duration.cs
@@ -145,19 +145,19 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
-            GameEvents.onLaunch.Add(new EventData<EventReport>.OnEvent(OnLaunch));
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
+            GameEvents.onLaunch.Add(OnLaunch);
+            GameEvents.Contract.onParameterChange.Add(OnParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
-            GameEvents.onLaunch.Remove(new EventData<EventReport>.OnEvent(OnLaunch));
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
+            GameEvents.onLaunch.Remove(OnLaunch);
+            GameEvents.Contract.onParameterChange.Remove(OnParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnParameterChange);
         }
 
         protected void OnContractAccepted(Contract contract)

--- a/source/ContractConfigurator/Parameter/HasAstronaut.cs
+++ b/source/ContractConfigurator/Parameter/HasAstronaut.cs
@@ -156,18 +156,18 @@ namespace ContractConfigurator.Parameters
         {
             base.OnRegister();
 
-            GameEvents.onVesselChange.Add(new EventData<Vessel>.OnEvent(OnVesselChange));
-            GameEvents.onKerbalStatusChange.Add(new EventData<ProtoCrewMember, ProtoCrewMember.RosterStatus, ProtoCrewMember.RosterStatus>.OnEvent(OnKerbalStatusChange));
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
+            GameEvents.onVesselChange.Add(OnVesselChange);
+            GameEvents.onKerbalStatusChange.Add(OnKerbalStatusChange);
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
 
-            GameEvents.onVesselChange.Remove(new EventData<Vessel>.OnEvent(OnVesselChange));
-            GameEvents.onKerbalStatusChange.Remove(new EventData<ProtoCrewMember, ProtoCrewMember.RosterStatus, ProtoCrewMember.RosterStatus>.OnEvent(OnKerbalStatusChange));
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
+            GameEvents.onVesselChange.Remove(OnVesselChange);
+            GameEvents.onKerbalStatusChange.Remove(OnKerbalStatusChange);
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
         }
 
         protected void OnVesselChange(Vessel v)

--- a/source/ContractConfigurator/Parameter/KerbalDeathsCustom.cs
+++ b/source/ContractConfigurator/Parameter/KerbalDeathsCustom.cs
@@ -84,23 +84,23 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onCrewKilled.Add(new EventData<EventReport>.OnEvent(OnCrewKilled));
-            GameEvents.onVesselChange.Add(new EventData<Vessel>.OnEvent(OnVesselChange));
-            GameEvents.onVesselCreate.Add(new EventData<Vessel>.OnEvent(OnVesselCreate));
-            ContractVesselTracker.OnVesselAssociation.Add(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselAssociation));
-            ContractVesselTracker.OnVesselDisassociation.Add(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselDisassociation));
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.onCrewKilled.Add(OnCrewKilled);
+            GameEvents.onVesselChange.Add(OnVesselChange);
+            GameEvents.onVesselCreate.Add(OnVesselCreate);
+            ContractVesselTracker.OnVesselAssociation.Add(OnVesselAssociation);
+            ContractVesselTracker.OnVesselDisassociation.Add(OnVesselDisassociation);
+            GameEvents.Contract.onParameterChange.Add(OnParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onCrewKilled.Remove(new EventData<EventReport>.OnEvent(OnCrewKilled));
-            GameEvents.onVesselChange.Remove(new EventData<Vessel>.OnEvent(OnVesselChange));
-            GameEvents.onVesselCreate.Remove(new EventData<Vessel>.OnEvent(OnVesselCreate));
-            ContractVesselTracker.OnVesselAssociation.Remove(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselAssociation));
-            ContractVesselTracker.OnVesselDisassociation.Remove(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselDisassociation));
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.onCrewKilled.Remove(OnCrewKilled);
+            GameEvents.onVesselChange.Remove(OnVesselChange);
+            GameEvents.onVesselCreate.Remove(OnVesselCreate);
+            ContractVesselTracker.OnVesselAssociation.Remove(OnVesselAssociation);
+            ContractVesselTracker.OnVesselDisassociation.Remove(OnVesselDisassociation);
+            GameEvents.Contract.onParameterChange.Remove(OnParameterChange);
         }
 
         protected override void OnParameterSave(ConfigNode node)

--- a/source/ContractConfigurator/Parameter/MissionTimer.cs
+++ b/source/ContractConfigurator/Parameter/MissionTimer.cs
@@ -23,12 +23,12 @@ namespace ContractConfigurator.Parameters
             {
                 this.missionTimer = missionTimer;
 
-                GameEvents.Contract.onCompleted.Add(new EventData<Contract>.OnEvent(OnContractCompleted));
+                GameEvents.Contract.onCompleted.Add(OnContractCompleted);
             }
 
             public void UnbindFromEvents()
             {
-                GameEvents.Contract.onCompleted.Remove(new EventData<Contract>.OnEvent(OnContractCompleted));
+                GameEvents.Contract.onCompleted.Remove(OnContractCompleted);
             }
 
             protected void OnContractCompleted(Contract contract)
@@ -131,20 +131,20 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
-            GameEvents.onLaunch.Add(new EventData<EventReport>.OnEvent(OnLaunch));
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
+            GameEvents.onLaunch.Add(OnLaunch);
+            GameEvents.Contract.onParameterChange.Add(OnParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
             checker?.UnbindFromEvents();
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
-            GameEvents.onLaunch.Remove(new EventData<EventReport>.OnEvent(OnLaunch));
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
+            GameEvents.onLaunch.Remove(OnLaunch);
+            GameEvents.Contract.onParameterChange.Remove(OnParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnParameterChange);
         }
 
         protected void OnContractAccepted(Contract contract)

--- a/source/ContractConfigurator/Parameter/None.cs
+++ b/source/ContractConfigurator/Parameter/None.cs
@@ -60,15 +60,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Add(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnAnyContractParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Remove(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnAnyContractParameterChange);
         }
 
         protected void OnAnyContractParameterChange(Contract contract, ContractParameter contractParameter)

--- a/source/ContractConfigurator/Parameter/Not.cs
+++ b/source/ContractConfigurator/Parameter/Not.cs
@@ -52,15 +52,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Add(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnAnyContractParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnAnyContractParameterChange));
+            GameEvents.Contract.onParameterChange.Remove(OnAnyContractParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnAnyContractParameterChange);
         }
 
         protected void OnAnyContractParameterChange(Contract contract, ContractParameter contractParameter)

--- a/source/ContractConfigurator/Parameter/ReachSpaceCustom.cs
+++ b/source/ContractConfigurator/Parameter/ReachSpaceCustom.cs
@@ -50,13 +50,13 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselSituationChange.Add(new EventData<GameEvents.HostedFromToAction<Vessel,Vessel.Situations>>.OnEvent(OnVesselSituationChange));
+            GameEvents.onVesselSituationChange.Add(OnVesselSituationChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselSituationChange.Remove(new EventData<GameEvents.HostedFromToAction<Vessel, Vessel.Situations>>.OnEvent(OnVesselSituationChange));
+            GameEvents.onVesselSituationChange.Remove(OnVesselSituationChange);
         }
 
         protected void OnVesselSituationChange(GameEvents.HostedFromToAction<Vessel, Vessel.Situations> hfta)

--- a/source/ContractConfigurator/Parameter/RecoverKerbalCustom.cs
+++ b/source/ContractConfigurator/Parameter/RecoverKerbalCustom.cs
@@ -127,23 +127,23 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselCreate.Add(new EventData<Vessel>.OnEvent(OnVesselCreate));
-            GameEvents.onCrewTransferred.Add(new EventData<GameEvents.HostedFromToAction<ProtoCrewMember, Part>>.OnEvent(OnCrewTransferred));
-            GameEvents.onVesselRecovered.Add(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
-            GameEvents.onCrewKilled.Add(new EventData<EventReport>.OnEvent(OnCrewKilled));
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.onVesselCreate.Add(OnVesselCreate);
+            GameEvents.onCrewTransferred.Add(OnCrewTransferred);
+            GameEvents.onVesselRecovered.Add(OnVesselRecovered);
+            GameEvents.onCrewKilled.Add(OnCrewKilled);
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
+            ContractConfigurator.OnParameterChange.Add(OnParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselCreate.Remove(new EventData<Vessel>.OnEvent(OnVesselCreate));
-            GameEvents.onCrewTransferred.Remove(new EventData<GameEvents.HostedFromToAction<ProtoCrewMember, Part>>.OnEvent(OnCrewTransferred));
-            GameEvents.onVesselRecovered.Remove(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
-            GameEvents.onCrewKilled.Remove(new EventData<EventReport>.OnEvent(OnCrewKilled));
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.onVesselCreate.Remove(OnVesselCreate);
+            GameEvents.onCrewTransferred.Remove(OnCrewTransferred);
+            GameEvents.onVesselRecovered.Remove(OnVesselRecovered);
+            GameEvents.onCrewKilled.Remove(OnCrewKilled);
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
+            ContractConfigurator.OnParameterChange.Remove(OnParameterChange);
         }
 
         private void OnVesselCreate(Vessel v)

--- a/source/ContractConfigurator/Parameter/Sequence.cs
+++ b/source/ContractConfigurator/Parameter/Sequence.cs
@@ -67,15 +67,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onParameterChange.Add(OnParameterChange);
+            ContractConfigurator.OnParameterChange.Add(OnParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onParameterChange.Remove(OnParameterChange);
+            ContractConfigurator.OnParameterChange.Remove(OnParameterChange);
         }
 
         protected void OnParameterChange(Contract contract, ContractParameter contractParameter)

--- a/source/ContractConfigurator/Parameter/TargetDestroyed.cs
+++ b/source/ContractConfigurator/Parameter/TargetDestroyed.cs
@@ -112,8 +112,8 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselWillDestroy.Add(new EventData<Vessel>.OnEvent(OnVesselWillDestroy));
-            GameEvents.onVesselWasModified.Add(new EventData<Vessel>.OnEvent(OnVesselWasModified));
+            GameEvents.onVesselWillDestroy.Add(OnVesselWillDestroy);
+            GameEvents.onVesselWasModified.Add(OnVesselWasModified);
 
             // Add a waypoint for each possible vessel in the list
             foreach (string vesselKey in vessels)
@@ -127,8 +127,8 @@ namespace ContractConfigurator.Parameters
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselWillDestroy.Remove(new EventData<Vessel>.OnEvent(OnVesselWillDestroy));
-            GameEvents.onVesselWasModified.Add(new EventData<Vessel>.OnEvent(OnVesselWasModified));
+            GameEvents.onVesselWillDestroy.Remove(OnVesselWillDestroy);
+            GameEvents.onVesselWasModified.Add(OnVesselWasModified);
 
             foreach (VesselWaypoint vesselWaypoint in vesselWaypoints)
             {

--- a/source/ContractConfigurator/Parameter/Timer.cs
+++ b/source/ContractConfigurator/Parameter/Timer.cs
@@ -83,19 +83,19 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
-            GameEvents.onLaunch.Add(new EventData<EventReport>.OnEvent(OnLaunch));
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
+            GameEvents.onLaunch.Add(OnLaunch);
+            GameEvents.Contract.onParameterChange.Add(OnParameterChange);
+            GameEvents.Contract.onParameterChange.Add(OnParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
-            GameEvents.onLaunch.Remove(new EventData<EventReport>.OnEvent(OnLaunch));
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
+            GameEvents.onLaunch.Remove(OnLaunch);
+            GameEvents.Contract.onParameterChange.Remove(OnParameterChange);
+            GameEvents.Contract.onParameterChange.Remove(OnParameterChange);
         }
 
         protected void OnContractAccepted(Contract contract)

--- a/source/ContractConfigurator/Parameter/VesselParameter.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter.cs
@@ -292,25 +292,25 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onFlightReady.Add(new EventVoid.OnEvent(OnFlightReady));
-            GameEvents.onVesselCreate.Add(new EventData<Vessel>.OnEvent(OnVesselCreate));
-            GameEvents.onVesselChange.Add(new EventData<Vessel>.OnEvent(OnVesselChange));
-            GameEvents.onPartJointBreak.Add(new EventData<PartJoint, float>.OnEvent(OnPartJointBreak));
-            GameEvents.onPartAttach.Add(new EventData<GameEvents.HostTargetAction<Part, Part>>.OnEvent(OnPartAttach));
-            GameEvents.onCrewTransferred.Add(new EventData<GameEvents.HostedFromToAction<ProtoCrewMember, Part>>.OnEvent(OnCrewTransferred));
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
+            GameEvents.onFlightReady.Add(OnFlightReady);
+            GameEvents.onVesselCreate.Add(OnVesselCreate);
+            GameEvents.onVesselChange.Add(OnVesselChange);
+            GameEvents.onPartJointBreak.Add(OnPartJointBreak);
+            GameEvents.onPartAttach.Add(OnPartAttach);
+            GameEvents.onCrewTransferred.Add(OnCrewTransferred);
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onFlightReady.Remove(new EventVoid.OnEvent(OnFlightReady));
-            GameEvents.onVesselCreate.Remove(new EventData<Vessel>.OnEvent(OnVesselCreate));
-            GameEvents.onVesselChange.Remove(new EventData<Vessel>.OnEvent(OnVesselChange));
-            GameEvents.onPartJointBreak.Remove(new EventData<PartJoint, float>.OnEvent(OnPartJointBreak));
-            GameEvents.onPartAttach.Remove(new EventData<GameEvents.HostTargetAction<Part, Part>>.OnEvent(OnPartAttach));
-            GameEvents.onCrewTransferred.Remove(new EventData<GameEvents.HostedFromToAction<ProtoCrewMember, Part>>.OnEvent(OnCrewTransferred));
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
+            GameEvents.onFlightReady.Remove(OnFlightReady);
+            GameEvents.onVesselCreate.Remove(OnVesselCreate);
+            GameEvents.onVesselChange.Remove(OnVesselChange);
+            GameEvents.onPartJointBreak.Remove(OnPartJointBreak);
+            GameEvents.onPartAttach.Remove(OnPartAttach);
+            GameEvents.onCrewTransferred.Remove(OnCrewTransferred);
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
         }
 
         protected virtual void OnCrewTransferred(GameEvents.HostedFromToAction<ProtoCrewMember, Part> a)

--- a/source/ContractConfigurator/Parameter/VesselParameter/CollectScienceCustom.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/CollectScienceCustom.cs
@@ -380,16 +380,16 @@ namespace ContractConfigurator.Parameters
         {
             base.OnRegister();
 
-            GameEvents.OnExperimentDeployed.Add(new EventData<ScienceData>.OnEvent(OnExperimentDeployed));
-            GameEvents.OnScienceRecieved.Add(new EventData<float, ScienceSubject, ProtoVessel, bool>.OnEvent(OnScienceReceived));
+            GameEvents.OnExperimentDeployed.Add(OnExperimentDeployed);
+            GameEvents.OnScienceRecieved.Add(OnScienceReceived);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
 
-            GameEvents.OnExperimentDeployed.Remove(new EventData<ScienceData>.OnEvent(OnExperimentDeployed));
-            GameEvents.OnScienceRecieved.Remove(new EventData<float, ScienceSubject, ProtoVessel, bool>.OnEvent(OnScienceReceived));
+            GameEvents.OnExperimentDeployed.Remove(OnExperimentDeployed);
+            GameEvents.OnScienceRecieved.Remove(OnScienceReceived);
         }
 
         protected void OnExperimentDeployed(ScienceData scienceData)

--- a/source/ContractConfigurator/Parameter/VesselParameter/Docking.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/Docking.cs
@@ -79,7 +79,7 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselDestroy.Add(new EventData<Vessel>.OnEvent(OnVesselDestroy));
+            GameEvents.onVesselDestroy.Add(OnVesselDestroy);
 
             // Add a waypoint for each possible vessel in the list
             foreach (string vesselKey in vessels)
@@ -93,7 +93,7 @@ namespace ContractConfigurator.Parameters
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselDestroy.Remove(new EventData<Vessel>.OnEvent(OnVesselDestroy));
+            GameEvents.onVesselDestroy.Remove(OnVesselDestroy);
 
             foreach (VesselWaypoint vesselWaypoint in vesselWaypoints)
             {

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
@@ -271,17 +271,17 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onCrewTransferred.Add(new EventData<GameEvents.HostedFromToAction<ProtoCrewMember, Part>>.OnEvent(OnCrewTransferred));
-            GameEvents.onVesselWasModified.Add(new EventData<Vessel>.OnEvent(OnVesselWasModified));
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
+            GameEvents.onCrewTransferred.Add(OnCrewTransferred);
+            GameEvents.onVesselWasModified.Add(OnVesselWasModified);
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onCrewTransferred.Remove(new EventData<GameEvents.HostedFromToAction<ProtoCrewMember, Part>>.OnEvent(OnCrewTransferred));
-            GameEvents.onVesselWasModified.Remove(new EventData<Vessel>.OnEvent(OnVesselWasModified));
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
+            GameEvents.onCrewTransferred.Remove(OnCrewTransferred);
+            GameEvents.onVesselWasModified.Remove(OnVesselWasModified);
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
         }
 
         private void OnContractAccepted(Contract c)

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasPassengers.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasPassengers.cs
@@ -148,17 +148,17 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onCrewTransferred.Add(new EventData<GameEvents.HostedFromToAction<ProtoCrewMember, Part>>.OnEvent(OnCrewTransferred));
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
-            SpawnPassengers.onPassengersLoaded.Add(new EventVoid.OnEvent(OnPassengersLoaded));
+            GameEvents.onCrewTransferred.Add(OnCrewTransferred);
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
+            SpawnPassengers.onPassengersLoaded.Add(OnPassengersLoaded);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onCrewTransferred.Remove(new EventData<GameEvents.HostedFromToAction<ProtoCrewMember, Part>>.OnEvent(OnCrewTransferred));
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
-            SpawnPassengers.onPassengersLoaded.Remove(new EventVoid.OnEvent(OnPassengersLoaded));
+            GameEvents.onCrewTransferred.Remove(OnCrewTransferred);
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
+            SpawnPassengers.onPassengersLoaded.Remove(OnPassengersLoaded);
         }
 
         protected void OnContractAccepted(Contract contract)

--- a/source/ContractConfigurator/Parameter/VesselParameter/IsNotVessel.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/IsNotVessel.cs
@@ -61,15 +61,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            ContractVesselTracker.OnVesselAssociation.Add(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselAssociation));
-            ContractVesselTracker.OnVesselDisassociation.Add(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselDisassociation));
+            ContractVesselTracker.OnVesselAssociation.Add(OnVesselAssociation);
+            ContractVesselTracker.OnVesselDisassociation.Add(OnVesselDisassociation);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            ContractVesselTracker.OnVesselAssociation.Remove(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselAssociation));
-            ContractVesselTracker.OnVesselDisassociation.Remove(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselDisassociation));
+            ContractVesselTracker.OnVesselAssociation.Remove(OnVesselAssociation);
+            ContractVesselTracker.OnVesselDisassociation.Remove(OnVesselDisassociation);
         }
 
         protected void OnVesselAssociation(GameEvents.HostTargetAction<Vessel, string> pair)

--- a/source/ContractConfigurator/Parameter/VesselParameter/NewVessel.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/NewVessel.cs
@@ -46,13 +46,13 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
         }
 
         protected void OnContractAccepted(Contract c)

--- a/source/ContractConfigurator/Parameter/VesselParameter/NoStaging.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/NoStaging.cs
@@ -58,13 +58,13 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onStageSeparation.Add(new EventData<EventReport>.OnEvent(OnStageSeparation));
+            GameEvents.onStageSeparation.Add(OnStageSeparation);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onStageSeparation.Remove(new EventData<EventReport>.OnEvent(OnStageSeparation));
+            GameEvents.onStageSeparation.Remove(OnStageSeparation);
         }
 
         protected void OnStageSeparation(EventReport er)

--- a/source/ContractConfigurator/Parameter/VesselParameter/PartValidation.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/PartValidation.cs
@@ -271,13 +271,13 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselWasModified.Add(new EventData<Vessel>.OnEvent(OnVesselWasModified));
+            GameEvents.onVesselWasModified.Add(OnVesselWasModified);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselWasModified.Remove(new EventData<Vessel>.OnEvent(OnVesselWasModified));
+            GameEvents.onVesselWasModified.Remove(OnVesselWasModified);
         }
 
         protected void OnVesselWasModified(Vessel v)

--- a/source/ContractConfigurator/Parameter/VesselParameter/PlantFlagCustom.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/PlantFlagCustom.cs
@@ -59,13 +59,13 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onFlagPlant.Add(new EventData<Vessel>.OnEvent(OnPlantFlag));
+            GameEvents.onFlagPlant.Add(OnPlantFlag);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onFlagPlant.Remove(new EventData<Vessel>.OnEvent(OnPlantFlag));
+            GameEvents.onFlagPlant.Remove(OnPlantFlag);
         }
 
         protected void OnPlantFlag(Vessel v)

--- a/source/ContractConfigurator/Parameter/VesselParameter/RecoverVessel.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/RecoverVessel.cs
@@ -43,13 +43,13 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselRecovered.Add(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
+            GameEvents.onVesselRecovered.Add(OnVesselRecovered);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselRecovered.Remove(new EventData<ProtoVessel, bool>.OnEvent(OnVesselRecovered));
+            GameEvents.onVesselRecovered.Remove(OnVesselRecovered);
         }
 
         private void OnVesselRecovered(ProtoVessel v, bool quick)

--- a/source/ContractConfigurator/Parameter/VesselParameter/ReturnHome.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/ReturnHome.cs
@@ -40,15 +40,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselSituationChange.Add(new EventData<GameEvents.HostedFromToAction<Vessel, Vessel.Situations>>.OnEvent(OnVesselSituationChange));
-            GameEvents.Contract.onParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.onVesselSituationChange.Add(OnVesselSituationChange);
+            GameEvents.Contract.onParameterChange.Add(OnParameterChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselSituationChange.Remove(new EventData<GameEvents.HostedFromToAction<Vessel, Vessel.Situations>>.OnEvent(OnVesselSituationChange));
-            GameEvents.Contract.onParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+            GameEvents.onVesselSituationChange.Remove(OnVesselSituationChange);
+            GameEvents.Contract.onParameterChange.Remove(OnParameterChange);
         }
 
         protected void OnVesselSituationChange(GameEvents.HostedFromToAction<Vessel, Vessel.Situations> pair)

--- a/source/ContractConfigurator/Parameter/VesselParameter/VesselDestroyed.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/VesselDestroyed.cs
@@ -61,19 +61,19 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onCollision.Add(new EventData<EventReport>.OnEvent(OnVesselAboutToBeDestroyed));
-            GameEvents.onCrash.Add(new EventData<EventReport>.OnEvent(OnVesselAboutToBeDestroyed));
-            GameEvents.onVesselDestroy.Add(new EventData<Vessel>.OnEvent(OnVesselDestroy));
-            GameEvents.onVesselWillDestroy.Add(new EventData<Vessel>.OnEvent(OnVesselDestroy));
+            GameEvents.onCollision.Add(OnVesselAboutToBeDestroyed);
+            GameEvents.onCrash.Add(OnVesselAboutToBeDestroyed);
+            GameEvents.onVesselDestroy.Add(OnVesselDestroy);
+            GameEvents.onVesselWillDestroy.Add(OnVesselDestroy);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onCollision.Remove(new EventData<EventReport>.OnEvent(OnVesselAboutToBeDestroyed));
-            GameEvents.onCrash.Remove(new EventData<EventReport>.OnEvent(OnVesselAboutToBeDestroyed));
-            GameEvents.onVesselDestroy.Remove(new EventData<Vessel>.OnEvent(OnVesselDestroy));
-            GameEvents.onVesselWillDestroy.Remove(new EventData<Vessel>.OnEvent(OnVesselDestroy));
+            GameEvents.onCollision.Remove(OnVesselAboutToBeDestroyed);
+            GameEvents.onCrash.Remove(OnVesselAboutToBeDestroyed);
+            GameEvents.onVesselDestroy.Remove(OnVesselDestroy);
+            GameEvents.onVesselWillDestroy.Remove(OnVesselDestroy);
         }
 
         protected virtual void OnVesselAboutToBeDestroyed(EventReport report)

--- a/source/ContractConfigurator/Parameter/VesselParameter/VesselHasVisited.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/VesselHasVisited.cs
@@ -106,13 +106,13 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselSituationChange.Add(new EventData<GameEvents.HostedFromToAction<Vessel, Vessel.Situations>>.OnEvent(OnVesselSituationChange));
+            GameEvents.onVesselSituationChange.Add(OnVesselSituationChange);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselSituationChange.Remove(new EventData<GameEvents.HostedFromToAction<Vessel, Vessel.Situations>>.OnEvent(OnVesselSituationChange));
+            GameEvents.onVesselSituationChange.Remove(OnVesselSituationChange);
         }
 
         protected void OnVesselSituationChange(GameEvents.HostedFromToAction<Vessel, Vessel.Situations> pair)

--- a/source/ContractConfigurator/Parameter/VesselParameter/VesselIsType.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/VesselIsType.cs
@@ -58,15 +58,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselWasModified.Add(new EventData<Vessel>.OnEvent(OnVesselWasModified));
-            GameEvents.onVesselRename.Add(new EventData<GameEvents.HostedFromToAction<Vessel,string>>.OnEvent(OnVesselRename));
+            GameEvents.onVesselWasModified.Add(OnVesselWasModified);
+            GameEvents.onVesselRename.Add(OnVesselRename);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselWasModified.Remove(new EventData<Vessel>.OnEvent(OnVesselWasModified));
-            GameEvents.onVesselRename.Remove(new EventData<GameEvents.HostedFromToAction<Vessel, string>>.OnEvent(OnVesselRename));
+            GameEvents.onVesselWasModified.Remove(OnVesselWasModified);
+            GameEvents.onVesselRename.Remove(OnVesselRename);
         }
 
         protected override void OnFlightReady()

--- a/source/ContractConfigurator/Parameter/VesselParameter/VesselNotDestroyed.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/VesselNotDestroyed.cs
@@ -89,15 +89,15 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselWillDestroy.Add(new EventData<Vessel>.OnEvent(OnVesselWillDestroy));
-            GameEvents.onPartDie.Add(new EventData<Part>.OnEvent(OnPartDie));
+            GameEvents.onVesselWillDestroy.Add(OnVesselWillDestroy);
+            GameEvents.onPartDie.Add(OnPartDie);
         }
 
         protected override void OnUnregister()
         {
             base.OnUnregister();
-            GameEvents.onVesselWillDestroy.Remove(new EventData<Vessel>.OnEvent(OnVesselWillDestroy));
-            GameEvents.onPartDie.Remove(new EventData<Part>.OnEvent(OnPartDie));
+            GameEvents.onVesselWillDestroy.Remove(OnVesselWillDestroy);
+            GameEvents.onPartDie.Remove(OnPartDie);
         }
 
         protected override void OnVesselChange(Vessel vessel)

--- a/source/ContractConfigurator/Parameter/VesselParameter/VisitWaypoint.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/VisitWaypoint.cs
@@ -27,12 +27,12 @@ namespace ContractConfigurator.Parameters
             public WaypointChecker(VisitWaypoint vw)
             {
                 visitWaypoint = vw;
-                ContractConfigurator.OnParameterChange.Add(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+                ContractConfigurator.OnParameterChange.Add(OnParameterChange);
             }
 
             public void UnbindFromEvents()
             {
-                ContractConfigurator.OnParameterChange.Remove(new EventData<Contract, ContractParameter>.OnEvent(OnParameterChange));
+                ContractConfigurator.OnParameterChange.Remove(OnParameterChange);
             }
 
             protected void OnParameterChange(Contract c, ContractParameter p)

--- a/source/ContractConfigurator/Parameter/VesselParameterGroup.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameterGroup.cs
@@ -412,7 +412,7 @@ namespace ContractConfigurator.Parameters
                 }
 
                 // Register these early, otherwise we'll miss the event
-                ConfiguredContract.OnContractLoaded.Add(new EventData<ConfiguredContract>.OnEvent(OnContractLoaded));
+                ConfiguredContract.OnContractLoaded.Add(OnContractLoaded);
                 if (resetChildrenWhenVesselDestroyed && Root.ContractState == Contract.State.Active)
                 {
                     ContractVesselTracker.OnKeyedVesselDestroyed.Add(OnKeyedVesselDestroyed);
@@ -430,13 +430,13 @@ namespace ContractConfigurator.Parameters
         protected override void OnRegister()
         {
             base.OnRegister();
-            GameEvents.onVesselChange.Add(new EventData<Vessel>.OnEvent(OnVesselChange));
-            ContractVesselTracker.OnVesselAssociation.Add(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselAssociation));
-            ContractVesselTracker.OnVesselDisassociation.Add(new EventData<GameEvents.HostTargetAction<Vessel, string>>.OnEvent(OnVesselDisassociation));
+            GameEvents.onVesselChange.Add(OnVesselChange);
+            ContractVesselTracker.OnVesselAssociation.Add(OnVesselAssociation);
+            ContractVesselTracker.OnVesselDisassociation.Add(OnVesselDisassociation);
 
-            GameEvents.Contract.onCompleted.Add(new EventData<Contract>.OnEvent(OnContractCompleted));
-            GameEvents.Contract.onFailed.Add(new EventData<Contract>.OnEvent(OnContractFailed));
-            GameEvents.Contract.onCancelled.Add(new EventData<Contract>.OnEvent(OnContractFailed));
+            GameEvents.Contract.onCompleted.Add(OnContractCompleted);
+            GameEvents.Contract.onFailed.Add(OnContractFailed);
+            GameEvents.Contract.onCancelled.Add(OnContractFailed);
 
             // Add a waypoint for each possible vessel in the list
             foreach (string vesselKey in vesselList)

--- a/source/ContractConfigurator/ScenarioModules/ContractPreLoader.cs
+++ b/source/ContractConfigurator/ScenarioModules/ContractPreLoader.cs
@@ -44,22 +44,22 @@ namespace ContractConfigurator
 
         void Start()
         {
-            GameEvents.Contract.onOffered.Add(new EventData<Contract>.OnEvent(OnContractOffered));
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccept));
-            GameEvents.Contract.onFinished.Add(new EventData<Contract>.OnEvent(OnContractFinish));
-            GameEvents.Contract.onDeclined.Add(new EventData<Contract>.OnEvent(OnContractDecline));
-            GameEvents.Contract.onContractsLoaded.Add(new EventVoid.OnEvent(OnContractsLoaded));
-            GameEvents.OnProgressReached.Add(new EventData<ProgressNode>.OnEvent(OnProgressReached));
+            GameEvents.Contract.onOffered.Add(OnContractOffered);
+            GameEvents.Contract.onAccepted.Add(OnContractAccept);
+            GameEvents.Contract.onFinished.Add(OnContractFinish);
+            GameEvents.Contract.onDeclined.Add(OnContractDecline);
+            GameEvents.Contract.onContractsLoaded.Add(OnContractsLoaded);
+            GameEvents.OnProgressReached.Add(OnProgressReached);
         }
 
         void OnDestroy()
         {
-            GameEvents.Contract.onOffered.Remove(new EventData<Contract>.OnEvent(OnContractOffered));
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccept));
-            GameEvents.Contract.onFinished.Remove(new EventData<Contract>.OnEvent(OnContractFinish));
-            GameEvents.Contract.onDeclined.Remove(new EventData<Contract>.OnEvent(OnContractDecline));
-            GameEvents.Contract.onContractsLoaded.Remove(new EventVoid.OnEvent(OnContractsLoaded));
-            GameEvents.OnProgressReached.Remove(new EventData<ProgressNode>.OnEvent(OnProgressReached));
+            GameEvents.Contract.onOffered.Remove(OnContractOffered);
+            GameEvents.Contract.onAccepted.Remove(OnContractAccept);
+            GameEvents.Contract.onFinished.Remove(OnContractFinish);
+            GameEvents.Contract.onDeclined.Remove(OnContractDecline);
+            GameEvents.Contract.onContractsLoaded.Remove(OnContractsLoaded);
+            GameEvents.OnProgressReached.Remove(OnProgressReached);
 
             // Unregister anything from offered contracts
             foreach (ConfiguredContract contract in contracts)

--- a/source/ContractConfigurator/ScenarioModules/ContractVesselTracker.cs
+++ b/source/ContractConfigurator/ScenarioModules/ContractVesselTracker.cs
@@ -50,16 +50,16 @@ namespace ContractConfigurator
 
         public void Start()
         {
-            GameEvents.onPartJointBreak.Add(new EventData<PartJoint, float>.OnEvent(OnPartJointBreak));
-            GameEvents.onVesselWasModified.Add(new EventData<Vessel>.OnEvent(OnVesselWasModified));
-            GameEvents.onVesselDestroy.Add(new EventData<Vessel>.OnEvent(OnVesselDestroy));
+            GameEvents.onPartJointBreak.Add(OnPartJointBreak);
+            GameEvents.onVesselWasModified.Add(OnVesselWasModified);
+            GameEvents.onVesselDestroy.Add(OnVesselDestroy);
         }
 
         public void OnDestroy()
         {
-            GameEvents.onPartJointBreak.Remove(new EventData<PartJoint, float>.OnEvent(OnPartJointBreak));
-            GameEvents.onVesselWasModified.Remove(new EventData<Vessel>.OnEvent(OnVesselWasModified));
-            GameEvents.onVesselDestroy.Remove(new EventData<Vessel>.OnEvent(OnVesselDestroy));
+            GameEvents.onPartJointBreak.Remove(OnPartJointBreak);
+            GameEvents.onVesselWasModified.Remove(OnVesselWasModified);
+            GameEvents.onVesselDestroy.Remove(OnVesselDestroy);
         }
 
         public override void OnLoad(ConfigNode node)

--- a/source/ContractConfigurator/Util/DraftTwitchViewers.cs
+++ b/source/ContractConfigurator/Util/DraftTwitchViewers.cs
@@ -69,18 +69,18 @@ namespace ContractConfigurator
                 return;
             }
 
-            GameEvents.Contract.onAccepted.Add(new EventData<Contract>.OnEvent(OnContractAccepted));
-            ContractPreLoader.OnInitializeValues.Add(new EventVoid.OnEvent(OnPreLoaderInitializeValues));
-            ContractPreLoader.OnInitializeFail.Add(new EventVoid.OnEvent(OnPreLoaderInitializeFail));
+            GameEvents.Contract.onAccepted.Add(OnContractAccepted);
+            ContractPreLoader.OnInitializeValues.Add(OnPreLoaderInitializeValues);
+            ContractPreLoader.OnInitializeFail.Add(OnPreLoaderInitializeFail);
         }
 
         void OnDestroy()
         {
             Instance = null;
 
-            GameEvents.Contract.onAccepted.Remove(new EventData<Contract>.OnEvent(OnContractAccepted));
-            ContractPreLoader.OnInitializeValues.Remove(new EventVoid.OnEvent(OnPreLoaderInitializeValues));
-            ContractPreLoader.OnInitializeFail.Remove(new EventVoid.OnEvent(OnPreLoaderInitializeFail));
+            GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
+            ContractPreLoader.OnInitializeValues.Remove(OnPreLoaderInitializeValues);
+            ContractPreLoader.OnInitializeFail.Remove(OnPreLoaderInitializeFail);
         }
 
         void Update()


### PR DESCRIPTION
This is plain unnecessary and will prevent KSPCF from finding leaks.