### PR TITLE
Filter 0Harmony.dll out of CC's netkan

### DIFF
--- a/ContractConfiguratorRO.netkan
+++ b/ContractConfiguratorRO.netkan
@@ -28,7 +28,8 @@
     "install" : [
         {
             "file"       : "GameData/ContractConfigurator",
-            "install_to" : "GameData"
+            "install_to" : "GameData",
+            "filter"     : "0Harmony.dll"
         }
     ]
 }


### PR DESCRIPTION
Hi @siimav,

The latest CC release is not being added to CKAN because it's tripping a safeguard we put in place to avoid multiple bundled Harmony DLLs in GameData:

![image](https://user-images.githubusercontent.com/1559108/232252105-cb932967-34ab-4fff-accc-fb87360a930b.png)

This PR filters it out of the install, which should fix that problem.

(Please do **not** add `"provides": ["Harmony1"]` as the message suggests may be an option, that won't work out well. That was part of the migration plan from Harmony1 to Harmony2 and should not be used for new mods.)
