### PR TITLE
Add preview of contract parameters to All tab

### DIFF
--- a/GameData/ContractConfigurator/Localization/en-us.cfg
+++ b/GameData/ContractConfigurator/Localization/en-us.cfg
@@ -159,6 +159,7 @@ Localization
         #cc.mcui.status.met = Met
         #cc.mcui.status.unmet = Unmet
         #cc.mcui.req.failOnAcceptPrompt = The <<1>> contract is incompatible with\n<<2>>\n\nIf you accept this contract, all incompatible ones will fail. Are you sure?
+        #cc.mcui.unknownParam = Unknown parameter
 
 
         //////////////////////////////////////////////////////////////////////

--- a/GameData/ContractConfigurator/Localization/zh-cn.cfg
+++ b/GameData/ContractConfigurator/Localization/zh-cn.cfg
@@ -161,6 +161,7 @@ Localization
         #cc.mcui.status.met = 满足
         #cc.mcui.status.unmet = 未满足
         #cc.mcui.req.failOnAcceptPrompt = The <<1>> contract is incompatible with\n<<2>>\n\nIf you accept this contract, all incompatible ones will fail. Are you sure?
+        #cc.mcui.unknownParam = Unknown parameter
 
 
         //////////////////////////////////////////////////////////////////////

--- a/source/ContractConfigurator/ContractType.cs
+++ b/source/ContractConfigurator/ContractType.cs
@@ -168,6 +168,7 @@ namespace ContractConfigurator
         public float failureReputation;
         public float failureFunds;
         public float advanceFunds;
+        public bool supportsPreview = false;
         public bool trace = false;
         public bool loaded = false;
         public int maxConsecutiveGenerationFailures = 1;
@@ -242,6 +243,8 @@ namespace ContractConfigurator
                     LoggingUtil.logLevel = LoggingUtil.LogLevel.VERBOSE;
                     LoggingUtil.LogWarning(this, "Tracing enabled for contract type {0}", name);
                 }
+
+                valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "supportsPreview", x => supportsPreview = x, this, false);
 
                 // Load contract text details
                 valid &= ConfigNodeUtil.ParseValue<string>(configNode, "title", x => title = x, this);

--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -1607,7 +1607,10 @@ namespace ContractConfigurator.Util
 
             text += ContractRequirementText(contractType.Requirements);
 
-            text += ContractParameterText(contractType);
+            if (contractType.supportsPreview)
+            {
+                text += ContractParameterText(contractType);
+            }
 
             MissionControl.Instance.contractText.text = text;
         }

--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -12,7 +12,7 @@ using Contracts.Agents;
 using KSP.UI;
 using KSP.UI.Screens;
 using KSP.Localization;
-using CommNet.Network;
+using ContractConfigurator.Parameters;
 
 namespace ContractConfigurator.Util
 {
@@ -1681,29 +1681,75 @@ namespace ContractConfigurator.Util
         {
             foreach (ParameterFactory factory in paramFactories)
             {
-                sb.Append(indent);
+                bool hideChildren = false;
                 try
                 {
-                    ContractParameter param = factory.Generate(null);
+                    var param = factory.Generate(null) as ContractConfiguratorParameter;
                     if (param == null)
                     {
                         string text = !string.IsNullOrEmpty(factory.Title) ? factory.Title : Localizer.GetStringByTag("#cc.mcui.unknownParam");
+                        sb.Append(indent);
                         sb.AppendLine(text);
                     }
                     else
                     {
-                        sb.AppendLine(param.Title);
+                        string title = param.GetTitlePreview(out hideChildren);
+                        if (string.IsNullOrEmpty(title))
+                        {
+                            continue;
+                        }
+
+                        sb.Append(indent);
+                        sb.AppendLine(title);
+
+                        if (!hideChildren)
+                        {
+                            ChildParameterText(param, indent, sb);
+                        }
                     }
                 }
                 catch (Exception ex)
                 {
                     LoggingUtil.LogError(this, $"Exception while generating parameter {factory.GetType().Name}: {ex}");
+                    sb.Append(indent);
                     sb.AppendLine("Unknown parameter");
-
                 }
 
-                if (!factory.HideChildren && factory.ChildParameters.Count() > 0)
+                if (!hideChildren && !factory.HideChildren && factory.ChildParameters.Count() > 0)
                     ContractParameterText(factory.ChildParameters, indent + "    ", sb);
+            }
+        }
+
+        private void ChildParameterText(ContractConfiguratorParameter parameter, string indent, StringBuilder sb)
+        {
+            if (!parameter.hideChildren && parameter.ParameterCount > 0)
+            {
+                indent += "    ";
+                for (int i = 0; i < parameter.ParameterCount; i++)
+                {
+                    var childParam = parameter.GetParameter(i) as ContractConfiguratorParameter;
+                    if (childParam == null)
+                    {
+                        sb.Append(indent);
+                        sb.AppendLine(Localizer.GetStringByTag("#cc.mcui.unknownParam"));
+                        continue;
+                    }
+
+                    if (childParam is ParameterDelegate pd && pd.Trivial)
+                        continue;
+
+                    string title = childParam.GetTitlePreview(out bool hideChildren);
+                    if (string.IsNullOrEmpty(title))
+                        continue;
+
+                    sb.Append(indent);
+                    sb.AppendLine(title);
+
+                    if (!hideChildren)
+                    {
+                        ChildParameterText(childParam, indent, sb);
+                    }
+                }
             }
         }
 

--- a/source/ContractConfigurator/Parameter/ContractConfiguratorParameter.cs
+++ b/source/ContractConfigurator/Parameter/ContractConfiguratorParameter.cs
@@ -79,6 +79,30 @@ namespace ContractConfigurator.Parameters
             return output;
         }
 
+        public virtual string GetTitlePreview(out bool hideChildren)
+        {
+            try
+            {
+                if (hidden)
+                {
+                    hideChildren = true;
+                    return "";
+                }
+
+                string s = GetParameterTitlePreview(out hideChildren);
+                hideChildren |= string.IsNullOrEmpty(s);
+                return optional && !fakeOptional && string.IsNullOrEmpty(title) ?
+                    StringBuilderCache.Format("{0} {1}", Localizer.GetStringByTag("#cc.param.optionalTag"), s) :
+                    s;
+            }
+            catch (Exception e)
+            {
+                LoggingUtil.LogException(new ContractConfiguratorException(this, e));
+                hideChildren = true;
+                return "";
+            }
+        }
+
         protected override string GetHashString()
         {
             return (Root != null ? (Root.MissionSeed.ToString() + Root.DateAccepted.ToString()) : "") + ID;
@@ -91,6 +115,12 @@ namespace ContractConfigurator.Parameters
         protected virtual string GetParameterTitle()
         {
             return title;
+        }
+
+        protected virtual string GetParameterTitlePreview(out bool hideChildren)
+        {
+            hideChildren = false;
+            return GetParameterTitle();
         }
 
         protected override string GetNotes()

--- a/source/ContractConfigurator/Parameter/KerbalDeathsCustom.cs
+++ b/source/ContractConfigurator/Parameter/KerbalDeathsCustom.cs
@@ -72,6 +72,17 @@ namespace ContractConfigurator.Parameters
             return output;
         }
 
+        protected override string GetParameterTitlePreview(out bool hideChildren)
+        {
+            hideChildren = true;
+            if (!string.IsNullOrEmpty(title))
+            {
+                return title;
+            }
+
+            return Localizer.Format("#cc.param.KerbalDeaths.generic", countMax - 1);
+        }
+
         protected void CreateDelegates()
         {
             // Validate specific kerbals

--- a/source/ContractConfigurator/Parameter/RecoverKerbalCustom.cs
+++ b/source/ContractConfigurator/Parameter/RecoverKerbalCustom.cs
@@ -73,6 +73,18 @@ namespace ContractConfigurator.Parameters
             return output;
         }
 
+        protected override string GetParameterTitlePreview(out bool hideChildren)
+        {
+            if (!string.IsNullOrEmpty(title))
+            {
+                hideChildren = true;
+                return title;
+            }
+
+            hideChildren = false;
+            return Localizer.GetStringByTag("#cc.param.RecoverKerbal.many");
+        }
+
         protected void CreateDelegates()
         {
             foreach (Kerbal kerbal in kerbals)

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
@@ -60,78 +60,10 @@ namespace ContractConfigurator.Parameters
                         hideChildren = true;
                     }
 
-                    // Build the count string
-                    string countStr;
-                    if (maxCrew == 0)
-                    {
-                        countStr = Localizer.GetStringByTag("#cc.param.HasCrew.unmanned");
-                    }
-                    else if (maxCrew == int.MaxValue)
-                    {
-                        countStr = Localizer.Format("#cc.param.count.atLeast", minCrew);
-                    }
-                    else if (minCrew == 0)
-                    {
-                        countStr = Localizer.Format("#cc.param.count.atMost", maxCrew);
-                    }
-                    else if (minCrew == maxCrew)
-                    {
-                        countStr = Localizer.Format("#cc.param.count.exact", minCrew);
-                    }
-                    else
-                    {
-                        countStr = Localizer.Format("#cc.param.count.between", minCrew, maxCrew);
-                    }
-
-                    // Build the trait string
-                    string traitStr = null;
-                    if (!String.IsNullOrEmpty(trait))
-                    {
-                        traitStr = Localizer.Format("#cc.param.HasAstronaut.trait", LocalizationUtil.TraitTitle(trait));
-                    }
-
-                    // Build the experience string
-                    string experienceStr = null;
-                    if (minExperience != 0 && maxExperience != 5)
-                    {
-                        if (minExperience == 0)
-                        {
-                            experienceStr = Localizer.Format("#cc.param.HasAstronaut.experience.atMost", maxExperience);
-                        }
-                        else if (maxExperience == 5)
-                        {
-                            experienceStr = Localizer.Format("#cc.param.HasAstronaut.experience.atLeast", minExperience);
-                        }
-                        else if (minExperience == maxExperience)
-                        {
-                            experienceStr = Localizer.Format("#cc.param.HasAstronaut.experience.exact", minExperience);
-                        }
-                        else
-                        {
-                            experienceStr = Localizer.Format("#cc.param.HasAstronaut.experience.between", minExperience, maxExperience);
-                        }
-                    }
-
-                    // Build the output string
-                    if (String.IsNullOrEmpty(traitStr))
-                    {
-                        if (String.IsNullOrEmpty(experienceStr))
-                        {
-                            output = Localizer.Format("#cc.param.HasCrew.1", countStr);
-                        }
-                        else
-                        {
-                            output = Localizer.Format("#cc.param.HasCrew.2", countStr, experienceStr);
-                        }
-                    }
-                    else if (String.IsNullOrEmpty(experienceStr))
-                    {
-                        output = Localizer.Format("#cc.param.HasCrew.2", countStr, traitStr);
-                    }
-                    else
-                    {
-                        output = Localizer.Format("#cc.param.HasCrew.3", countStr, traitStr, experienceStr);
-                    }
+                    string countStr = BuildCrewCountString();
+                    string traitStr = BuildTraitString();
+                    string experienceStr = BuildExperienceString();
+                    output = CombineStrings(countStr, traitStr, experienceStr);
                 }
                 else
                 {
@@ -155,6 +87,88 @@ namespace ContractConfigurator.Parameters
                 output = title;
             }
             return output;
+        }
+
+        private string BuildCrewCountString()
+        {
+            if (maxCrew == 0)
+            {
+                return Localizer.GetStringByTag("#cc.param.HasCrew.unmanned");
+            }
+            else if (maxCrew == int.MaxValue)
+            {
+                return Localizer.Format("#cc.param.count.atLeast", minCrew);
+            }
+            else if (minCrew == 0)
+            {
+                return Localizer.Format("#cc.param.count.atMost", maxCrew);
+            }
+            else if (minCrew == maxCrew)
+            {
+                return Localizer.Format("#cc.param.count.exact", minCrew);
+            }
+            else
+            {
+                return Localizer.Format("#cc.param.count.between", minCrew, maxCrew);
+            }
+        }
+
+        private string BuildTraitString()
+        {
+            if (!String.IsNullOrEmpty(trait))
+            {
+                return Localizer.Format("#cc.param.HasAstronaut.trait", LocalizationUtil.TraitTitle(trait));
+            }
+
+            return null;
+        }
+
+        private string BuildExperienceString()
+        {
+            if (minExperience != 0 && maxExperience != 5)
+            {
+                if (minExperience == 0)
+                {
+                    return Localizer.Format("#cc.param.HasAstronaut.experience.atMost", maxExperience);
+                }
+                else if (maxExperience == 5)
+                {
+                    return Localizer.Format("#cc.param.HasAstronaut.experience.atLeast", minExperience);
+                }
+                else if (minExperience == maxExperience)
+                {
+                    return Localizer.Format("#cc.param.HasAstronaut.experience.exact", minExperience);
+                }
+                else
+                {
+                    return Localizer.Format("#cc.param.HasAstronaut.experience.between", minExperience, maxExperience);
+                }
+            }
+
+            return null;
+        }
+
+        private static string CombineStrings(string countStr, string traitStr, string experienceStr)
+        {
+            if (String.IsNullOrEmpty(traitStr))
+            {
+                if (String.IsNullOrEmpty(experienceStr))
+                {
+                    return Localizer.Format("#cc.param.HasCrew.1", countStr);
+                }
+                else
+                {
+                    return Localizer.Format("#cc.param.HasCrew.2", countStr, experienceStr);
+                }
+            }
+            else if (String.IsNullOrEmpty(experienceStr))
+            {
+                return Localizer.Format("#cc.param.HasCrew.2", countStr, traitStr);
+            }
+            else
+            {
+                return Localizer.Format("#cc.param.HasCrew.3", countStr, traitStr, experienceStr);
+            }
         }
 
         protected void CreateDelegates()

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
@@ -171,6 +171,21 @@ namespace ContractConfigurator.Parameters
             }
         }
 
+        protected override string GetParameterTitlePreview(out bool hideChildren)
+        {
+            if (!string.IsNullOrEmpty(title))
+            {
+                hideChildren = true;
+                return title;
+            }
+
+            hideChildren = true;
+            string countStr = BuildCrewCountString();
+            string traitStr = BuildTraitString();
+            string experienceStr = BuildExperienceString();
+            return CombineStrings(countStr, traitStr, experienceStr);
+        }
+
         protected void CreateDelegates()
         {
             // Experience trait

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasPassengers.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasPassengers.cs
@@ -72,6 +72,18 @@ namespace ContractConfigurator.Parameters
             return output;
         }
 
+        protected override string GetParameterTitlePreview(out bool hideChildren)
+        {
+            if (!string.IsNullOrEmpty(title))
+            {
+                hideChildren = true;
+                return title;
+            }
+
+            hideChildren = true;
+            return Localizer.Format("#cc.param.HasPassenger.summary", count > 0 ? count : passengers.Count);
+        }
+
         protected void CreateDelegates()
         {
             // Filter for passengers

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasResource.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasResource.cs
@@ -70,6 +70,26 @@ namespace ContractConfigurator.Parameters
             return output;
         }
 
+        protected override string GetParameterTitlePreview(out bool hideChildren)
+        {
+            if (!string.IsNullOrEmpty(title))
+            {
+                hideChildren = true;
+                return title;
+            }
+
+            if (ParameterCount == 1)
+            {
+                hideChildren = true;
+                return ParameterDelegate<Vessel>.GetDelegateText(this);
+            }
+            else
+            {
+                hideChildren = false;
+                return Localizer.GetStringByTag("#cc.param.HasResource");
+            }
+        }
+
         protected void CreateDelegates()
         {
             foreach (Filter filter in filters)

--- a/source/ContractConfigurator/Parameter/VesselParameter/ReachState.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/ReachState.cs
@@ -102,6 +102,26 @@ namespace ContractConfigurator.Parameters
             return output;
         }
 
+        protected override string GetParameterTitlePreview(out bool hideChildren)
+        {
+            if (!string.IsNullOrEmpty(title))
+            {
+                hideChildren = true;
+                return title;
+            }
+
+            if (ParameterCount == 1)
+            {
+                hideChildren = true;
+                return ParameterDelegate<Vessel>.GetDelegateText(this);
+            }
+            else
+            {
+                hideChildren = false;
+                return Localizer.GetStringByTag("#cc.param.ReachState");
+            }
+        }
+
         protected void CreateDelegates()
         {
             // Filter for celestial bodies

--- a/source/ContractConfigurator/ParameterFactory.cs
+++ b/source/ContractConfigurator/ParameterFactory.cs
@@ -44,6 +44,9 @@ namespace ContractConfigurator
         protected string notes;
         protected string completedMessage;
 
+        public bool HideChildren => hideChildren;
+        public string Title => title;
+
         public bool enabled = true;
         public bool hasWarnings { get; set; }
         public Type iteratorType { get; set; }

--- a/source/ContractConfigurator/ParameterFactory/ReachSpecificOrbitFactory.cs
+++ b/source/ContractConfigurator/ParameterFactory/ReachSpecificOrbitFactory.cs
@@ -36,7 +36,7 @@ namespace ContractConfigurator
         public override ContractParameter Generate(Contract contract)
         {
             // Get the OrbitGenerator behaviour
-            OrbitGenerator orbitGenerator = ((ConfiguredContract)contract).Behaviours.OfType<OrbitGenerator>().FirstOrDefault<OrbitGenerator>();
+            OrbitGenerator orbitGenerator = (contract as ConfiguredContract)?.Behaviours.OfType<OrbitGenerator>().FirstOrDefault<OrbitGenerator>();
 
             if (orbitGenerator == null)
             {

--- a/source/ContractConfigurator/ParameterFactory/VisitWaypointFactory.cs
+++ b/source/ContractConfigurator/ParameterFactory/VisitWaypointFactory.cs
@@ -38,6 +38,11 @@ namespace ContractConfigurator
 
         public override ContractParameter Generate(Contract contract)
         {
+            if (contract == null)
+            {
+                LoggingUtil.LogError(this, "Contract is null.");
+                return null;
+            }
             VisitWaypoint vw = new VisitWaypoint(index, distance, horizontalDistance, hideOnCompletion, showMessages, title);
             return vw.FetchWaypoint(contract) != null ? vw : null;
         }


### PR DESCRIPTION
Tries to generate every visible parameter when a contract is selected in the All tab. As a fallback if this fails, will try to use the Title field instead. Overall this approach appears to work rather well for contracts from RP-1 but no idea how usable it is for other contract packs.

By default is disabled on all contracts. To enable `supportsPreview = true` needs to be added to every individual `CONTRACT_TYPE`.