### PR TITLE
Replace all OnPartJointBreak events with OnPartDeCouple+OnPartUndock

### DIFF
--- a/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
@@ -313,19 +313,6 @@ namespace ContractConfigurator.Parameters
             CheckVessel(v);
         }
 
-        protected override void OnPartJointBreak(PartJoint p, float breakForce)
-        {
-            LoggingUtil.LogVerbose(this, "OnPartJointBreak: {0}", p);
-            base.OnPartJointBreak(p, breakForce);
-
-            if (HighLogic.LoadedScene == GameScenes.EDITOR || p.Parent.vessel == null)
-            {
-                return;
-            }
-
-            CheckVessel(p.Parent.vessel);
-        }
-
         protected override void OnCrewTransferred(GameEvents.HostedFromToAction<ProtoCrewMember, Part> a)
         {
             base.OnCrewTransferred(a);

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasCrewCapacity.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasCrewCapacity.cs
@@ -93,9 +93,15 @@ namespace ContractConfigurator.Parameters
             CheckVessel(FlightGlobals.ActiveVessel);
         }
 
-        protected override void OnPartJointBreak(PartJoint p, float breakForce)
+        protected override void OnPartUndock(Part part)
         {
-            base.OnPartJointBreak(p, breakForce);
+            base.OnPartUndock(part);
+            CheckVessel(FlightGlobals.ActiveVessel);
+        }
+
+        protected override void OnPartDeCouple(Part part)
+        {
+            base.OnPartDeCouple(part);
             CheckVessel(FlightGlobals.ActiveVessel);
         }
 

--- a/source/ContractConfigurator/Parameter/VesselParameter/PartValidation.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/PartValidation.cs
@@ -403,9 +403,15 @@ namespace ContractConfigurator.Parameters
             CheckVessel(FlightGlobals.ActiveVessel);
         }
 
-        protected override void OnPartJointBreak(PartJoint p, float breakForce)
+        protected override void OnPartUndock(Part part)
         {
-            base.OnPartJointBreak(p, breakForce);
+            base.OnPartUndock(part);
+            CheckVessel(FlightGlobals.ActiveVessel);
+        }
+
+        protected override void OnPartDeCouple(Part part)
+        {
+            base.OnPartDeCouple(part);
             CheckVessel(FlightGlobals.ActiveVessel);
         }
 

--- a/source/ContractConfigurator/Parameter/VesselParameter/VesselNotDestroyed.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/VesselNotDestroyed.cs
@@ -107,17 +107,27 @@ namespace ContractConfigurator.Parameters
             lastVesselChange = Time.fixedTime;
         }
 
-        protected override void OnPartJointBreak(PartJoint p, float breakForce)
+        protected override void OnPartUndock(Part part)
         {
-            base.OnPartJointBreak(p, breakForce);
+            base.OnPartUndock(part);
+            CheckAboutToCreateVesselFromPart(part);
+        }
 
-            if (HighLogic.LoadedScene == GameScenes.EDITOR || p?.Parent?.vessel == null)
+        protected override void OnPartDeCouple(Part part)
+        {
+            base.OnPartDeCouple(part);
+            CheckAboutToCreateVesselFromPart(part);
+        }
+
+        private void CheckAboutToCreateVesselFromPart(Part part)
+        {
+            if (HighLogic.LoadedScene == GameScenes.EDITOR || part?.vessel == null)
             {
                 return;
             }
 
-            Vessel v = p.Parent.vessel;
-            LoggingUtil.LogVerbose(this, "OnPartJointBreak: {0}", v.id);
+            Vessel v = part.vessel;
+            LoggingUtil.LogVerbose(this, "CheckAboutToCreateVesselFromPart: {0}", v.id);
             if (v.vesselType == VesselType.Debris)
             {
                 return;


### PR DESCRIPTION
Acting on joints breaking meant that every autostrut getting cycled or removed caused extreme amounts of unnecessary checks.