### PR TITLE
Fix for NRE in AllScienceSubjectsByBiomeExperiment()

### DIFF
--- a/source/ContractConfigurator/ExpressionParser/Parsers/Classes/Science/SubjectParser.cs
+++ b/source/ContractConfigurator/ExpressionParser/Parsers/Classes/Science/SubjectParser.cs
@@ -42,7 +42,7 @@ namespace ContractConfigurator.ExpressionParser
             RegisterGlobalFunction(new Function<List<Biome>, List<ScienceSubject>>("AllScienceSubjectsByBiome", (biomes) => Science.GetSubjects(biomes.GroupBy(b => b != null ? b.body : null).Select(grp => grp.First() != null ? grp.First().body : null), null, x => biomes.Any(b => b.biome == x)).ToList(), false));
 
             RegisterGlobalFunction(new Function<List<CelestialBody>, List<ScienceExperiment>, List<ScienceSubject>>("AllScienceSubjectsByBodyExperiment", (cbs, exps) => Science.GetSubjects(cbs, x => exps.Contains(x)).ToList(), false));
-            RegisterGlobalFunction(new Function<List<Biome>, List<ScienceExperiment>, List<ScienceSubject>>("AllScienceSubjectsByBiomeExperiment", (biomes, exps) => Science.GetSubjects(biomes.GroupBy(b => b.body).Select(grp => grp.First().body), x => exps.Contains(x), x => biomes.Any(b => b.biome == x)).ToList(), false));
+            RegisterGlobalFunction(new Function<List<Biome>, List<ScienceExperiment>, List<ScienceSubject>>("AllScienceSubjectsByBiomeExperiment", (biomes, exps) => Science.GetSubjects(biomes.GroupBy(b => b != null ? b.body : null).Select(grp => grp.First() != null ? grp.First().body : null), x => exps.Contains(x), x => biomes.Any(b => b.biome == x)).ToList(), false));
 
             RegisterGlobalFunction(new Function<List<ScienceSubject>>("DifficultScienceSubjects", () => Science.GetSubjects(FlightGlobals.Bodies, null, null, true).ToList(), false));
             RegisterGlobalFunction(new Function<List<CelestialBody>, List<ScienceSubject>>("DifficultScienceSubjectsByBody", (cbs) => Science.GetSubjects(cbs, null, null, true).ToList(), false));


### PR DESCRIPTION
Fix NRE for AllScienceSubjectsByBiomeExperiment() when parsing a biome that is encapulated in [] in a contract pack cfg.

In this case I was looking at a contract pack called [RAD](https://github.com/Morphisor244/Research-Advancement-Division/blob/main/GameData/ContractPacks/RAD/RAD_LocalFlight.cfg)

This specific contract would fail on line 68 when @biome1 is encapsulated in [] brackets.