### PR TITLE
Fix some issues and enhance PartValidation

### DIFF
--- a/GameData/ContractConfigurator/Localization/en-us.cfg
+++ b/GameData/ContractConfigurator/Localization/en-us.cfg
@@ -292,6 +292,8 @@ Localization
         #cc.param.PartValidation.withModuleType = with module type: <<1>>
         // <<With/All have/None have>> <<2>>: <<3>>
         #cc.param.PartValidation.generic = <<1>> <<c:2>>: <<3>>
+        #cc.param.PartValidation.generic.moduleRoot = <<1>> <<2>>
+        #cc.param.PartValidation.generic.moduleSub = <<1>>: <<2>>
         #cc.param.PartValidation.type = <<1>> type: <<2>>
         #cc.param.PartValidation.module = <<1>> module: <<2>>
         #cc.param.PartValidation.moduleType = <<1>> module type: <<2>>

--- a/source/ContractConfigurator/ParameterFactory/PartValidationFactory.cs
+++ b/source/ContractConfigurator/ParameterFactory/PartValidationFactory.cs
@@ -37,7 +37,7 @@ namespace ContractConfigurator
             }
 
             // Standard definition
-            if (configNode.HasValue("part") || configNode.HasValue("partModule") || configNode.HasValue("partModuleType") || configNode.HasValue("category") || configNode.HasValue("manufacturer"))
+            if (configNode.HasValue("part") || configNode.HasValue("partModule") || configNode.HasValue("partModuleType") || configNode.HasValue("category") || configNode.HasValue("manufacturer") || configNode.HasNode("MODULE"))
             {
                 PartValidation.Filter filter = new PartValidation.Filter(defaultMatch);
                 valid &= ConfigNodeUtil.ParseValue<List<AvailablePart>>(configNode, "part", x => filter.parts = x, this, new List<AvailablePart>());
@@ -60,6 +60,10 @@ namespace ContractConfigurator
                         else if (v.name == "label")
                         {
                             nextLabel = v.value;
+                        }
+                        else if (v.name == "title")
+                        {
+                            nextLabel = "¶" + v.value;
                         }
                         else
                         {
@@ -125,6 +129,10 @@ namespace ContractConfigurator
                         else if (v.name == "label")
                         {
                             nextLabel = v.value;
+                        }
+                        else if (v.name == "title")
+                        {
+                            nextLabel = "¶" + v.value;
                         }
                         else
                         {


### PR DESCRIPTION
Change PartValidation so that all checks in a MODULE node apply to the same module (as you'd expect). Also support using `title` instead of `label` which will be the entire loc string, rather than <label> = <whatever internal value was specified>. Add special handling for isEnabled = True / False which will check pm.IsEnabled rather than look for a basefield.

Also fix a bug where MODULE alone was insufficient for PartValidation to parse, instead requiring part= or partModule= or one of the other fields.