### PR TITLE
Support kerbals dying while parts themselves stay intact

### DIFF
--- a/source/ContractConfigurator/ContractConfigurator.cs
+++ b/source/ContractConfigurator/ContractConfigurator.cs
@@ -27,7 +27,7 @@ namespace ContractConfigurator
             LOAD_CONFIG,
         }
 
-        private static ContractConfigurator Instance;
+        internal static ContractConfigurator Instance;
 
         public static bool reloading = false;
         static ReloadStep reloadStep = ReloadStep.GAME_DATABASE;
@@ -43,6 +43,8 @@ namespace ContractConfigurator
 
         [Obsolete("Use GameEvents.Contract.onParameterChange instead")]
         public static EventData<Contract, ContractParameter> OnParameterChange = new EventData<Contract, ContractParameter>("OnParameterChange");
+
+        public static EventData<Vessel, ProtoCrewMember> OnVesselCrewDie = new EventData<Vessel, ProtoCrewMember>("OnVesselCrewDie");
 
         public static Dictionary<string, Type> contractTypeMap = new Dictionary<string, Type>();
 

--- a/source/ContractConfigurator/ContractConfigurator.csproj
+++ b/source/ContractConfigurator/ContractConfigurator.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Behaviour\UnlockPart.cs" />
     <Compile Include="Behaviour\UnlockTech.cs" />
     <Compile Include="HarmonyPatcher.cs" />
+    <Compile Include="Harmony\Kerbal.cs" />
     <Compile Include="Harmony\ContractSystem.cs" />
     <Compile Include="ScenarioModules\ScienceReporter.cs" />
     <Compile Include="ExpressionParser\Parsers\Classes\ExperienceTraitParser.cs" />

--- a/source/ContractConfigurator/Harmony/Kerbal.cs
+++ b/source/ContractConfigurator/Harmony/Kerbal.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+
+namespace ContractConfigurator.Harmony
+{
+    [HarmonyPatch(typeof(global::Kerbal))]
+    internal class PatchKerbal
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch("die")]
+        internal static void Postfix_Die(global::Kerbal __instance)
+        {
+            if (__instance.InVessel == null) return;
+
+            ContractConfigurator.OnVesselCrewDie.Fire(__instance.InVessel, __instance.protoCrewMember);
+        }
+    }
+}

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasCrew.cs
@@ -308,6 +308,7 @@ namespace ContractConfigurator.Parameters
             GameEvents.onCrewTransferred.Add(OnCrewTransferred);
             GameEvents.onVesselWasModified.Add(OnVesselWasModified);
             GameEvents.Contract.onAccepted.Add(OnContractAccepted);
+            ContractConfigurator.OnVesselCrewDie.Add(OnVesselCrewDie);
         }
 
         protected override void OnUnregister()
@@ -316,6 +317,7 @@ namespace ContractConfigurator.Parameters
             GameEvents.onCrewTransferred.Remove(OnCrewTransferred);
             GameEvents.onVesselWasModified.Remove(OnVesselWasModified);
             GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
+            ContractConfigurator.OnVesselCrewDie.Remove(OnVesselCrewDie);
         }
 
         private void OnContractAccepted(Contract c)
@@ -333,6 +335,11 @@ namespace ContractConfigurator.Parameters
                     kerbal.GenerateKerbal();
                 }
             }
+        }
+
+        private void OnVesselCrewDie(Vessel vessel, ProtoCrewMember pcm)
+        {
+            CheckVessel(vessel);
         }
 
         protected override void OnPartAttach(GameEvents.HostTargetAction<Part, Part> e)

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasPassengers.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasPassengers.cs
@@ -163,6 +163,7 @@ namespace ContractConfigurator.Parameters
             GameEvents.onCrewTransferred.Add(OnCrewTransferred);
             GameEvents.Contract.onAccepted.Add(OnContractAccepted);
             SpawnPassengers.onPassengersLoaded.Add(OnPassengersLoaded);
+            ContractConfigurator.OnVesselCrewDie.Add(OnVesselCrewDie);
         }
 
         protected override void OnUnregister()
@@ -171,6 +172,7 @@ namespace ContractConfigurator.Parameters
             GameEvents.onCrewTransferred.Remove(OnCrewTransferred);
             GameEvents.Contract.onAccepted.Remove(OnContractAccepted);
             SpawnPassengers.onPassengersLoaded.Remove(OnPassengersLoaded);
+            ContractConfigurator.OnVesselCrewDie.Remove(OnVesselCrewDie);
         }
 
         protected void OnContractAccepted(Contract contract)
@@ -190,6 +192,11 @@ namespace ContractConfigurator.Parameters
         protected void OnPassengersLoaded()
         {
             CheckVessel(FlightGlobals.ActiveVessel);
+        }
+
+        protected void OnVesselCrewDie(Vessel vessel, ProtoCrewMember pcm)
+        {
+            CheckVessel(vessel);
         }
 
         protected override void OnPartAttach(GameEvents.HostTargetAction<Part, Part> e)


### PR DESCRIPTION
Various life support mods can kill crew inside parts. Previously those changes weren't picked up in vessel parameters.