### PR TITLE
Fix Duration getting reset when wrapped inside Orbit

### DIFF
--- a/source/ContractConfigurator/Parameter/Duration.cs
+++ b/source/ContractConfigurator/Parameter/Duration.cs
@@ -225,7 +225,7 @@ namespace ContractConfigurator.Parameters
                 }
 
                 // Additional check when under a VesselParameterGroup
-                VesselParameterGroup vpg = Parent as VesselParameterGroup;
+                VesselParameterGroup vpg = GetParameterGroupHost();
                 if (vpg != null && vpg.VesselList.Any())
                 {
                     completed &= ContractVesselTracker.Instance.GetAssociatedKeys(FlightGlobals.ActiveVessel).

--- a/source/ContractConfigurator/Parameter/VesselParameter.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter.cs
@@ -713,7 +713,7 @@ namespace ContractConfigurator.Parameters
         protected Vessel CurrentVessel()
         {
             VesselParameterGroup vpg = GetParameterGroupHost();
-            return vpg == null ? null : vpg.TrackedVessel;
+            return vpg?.TrackedVessel;
         }
 
         protected VesselParameterGroup GetParameterGroupHost()

--- a/source/ContractConfigurator/Parameter/VesselParameter/OrbitParameter.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/OrbitParameter.cs
@@ -403,10 +403,11 @@ namespace ContractConfigurator.Parameters
         protected override void OnUpdate()
         {
             base.OnUpdate();
-            if (UnityEngine.Time.fixedTime - lastUpdate > UPDATE_FREQUENCY)
+            if (Time.fixedTime - lastUpdate > UPDATE_FREQUENCY)
             {
                 lastUpdate = UnityEngine.Time.fixedTime;
-                CheckVessel(FlightGlobals.ActiveVessel);
+                Vessel trackedVessel = CurrentVessel() ?? FlightGlobals.ActiveVessel;
+                CheckVessel(trackedVessel);
             }
         }
 


### PR DESCRIPTION
Turns out that Orbit parameter only runs checks on FlightGlobals.ActiveVessel which obviously is null in TS. Duration on the other hand is happy to invalidate the data for last tracked vessel as soon as any of the parameters are no longer met - including ones that are never even checked.