### PR TITLE
Fixed incorrect cc.req.CompleteContract.cooldown in localization

### DIFF
--- a/GameData/ContractConfigurator/Localization/en-us.cfg
+++ b/GameData/ContractConfigurator/Localization/en-us.cfg
@@ -361,7 +361,7 @@ Localization
         #cc.req.CanResearchTech.x = Must not be able to research <<1>>
         #cc.req.CompleteContract = Must have completed contract <<1>>
         #cc.req.CompleteContract.x = Must not have completed contract <<1>>
-        #cc.req.CompleteContract.cooldown = Must have completed contract <<1>> within the last <<2>>
+        #cc.req.CompleteContract.cooldown = Must have completed contract <<1>> but not in the last <<2>>
         #cc.req.CompleteContract.cooldown.x = Must not have completed contract <<1>> within the last <<2>>
         #cc.req.Expansion = Must have the <<1>> expansion installed
         #cc.req.Facility.exact = The <<1>> must be level <<n:2>>


### PR DESCRIPTION
cc.req.CompleteContract.cooldown aka "Must have completed contract <<1>> within the last <<2>>" is produced from .cfg like so:
```
REQUIREMENT
{
	type = CompleteContract

	contractType = someContract
	cooldownDuration = 23
}
```
"cooldown" is pretty much the opposite of "within the last". The actual logic in the plugin is a cooldown. Curiously the negative (#cc.req.CompleteContract.cooldown.x) is correct.
