### PR TITLE
Made usage of expressions in Contract Requirement possible

### DIFF
--- a/source/ContractConfigurator/Requirement/ContractCheckRequirement.cs
+++ b/source/ContractConfigurator/Requirement/ContractCheckRequirement.cs
@@ -28,23 +28,17 @@ namespace ContractConfigurator
             const string nullString = null; // to get around the fact this is overloaded.
             valid &= ConfigNodeUtil.ParseValue<string>(configNode, "tag", x => tag = x, this, nullString);
 
-            // Get type
-            string contractType = null;
-            valid &= tag != null || ConfigNodeUtil.ParseValue<string>(configNode, "contractType", x => contractType = x, this);
-
             // By default, always check the requirement for active contracts
             valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "checkOnActiveContract", x => checkOnActiveContract = x, this, true);
 
-            if (valid)
-            {
-                if (tag == null)
-                    valid &= SetValues(contractType);
-                else
-                    ccType = null;
-            }
+            // Get type
+            string dummy = null;
+            valid &= ConfigNodeUtil.ParseValue<string>(configNode, "contractType", x => dummy = x, this, SetValues);
 
             valid &= ConfigNodeUtil.ParseValue<uint>(configNode, "minCount", x => minCount = x, this, 1);
             valid &= ConfigNodeUtil.ParseValue<uint>(configNode, "maxCount", x => maxCount = x, this, UInt32.MaxValue);
+
+            valid &= ConfigNodeUtil.MutuallyExclusive(configNode, new string[] { "tag" }, new string[] { "contractType" }, this);
 
             return valid;
         }


### PR DESCRIPTION
I tried to generate a sequence of contracts with DATA_EXPAND and .cfg like so:
```
CONTRACT_TYPE
{
	name = ExampleContract
	DATA_EXPAND
	{
		type = int
		stage = [1, 2, 3]
	}
	DATA
	{
		type = int
		prev = @/stage - 1
	}
	REQUIREMENT
	{
		name = CompleteContract
		type = CompleteContract

		contractType = "ExampleContract."+@/prev
	}
	...
```
I got a NullReferenceException. The code for parsing "contractType" doesn't account for it not being immediately evaluated.
By simply using SetValues as ParseValue's validation seems to do the trick. Using validation to set values feels kinda hacky, but is not without a precedent within the codebase, see: WaypointGenerator.cs:433 and 463

I also added MutuallyExclusive since be the logic in the code "tag" and "contractType" are mutually exclusive, but util is not used for some reason and there's no feedback for the contract creator.