### PR TITLE
Fixed vessel not getting dissassociated on contract completion

### DIFF
--- a/source/ContractConfigurator/Parameter/VesselParameterGroup.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameterGroup.cs
@@ -473,6 +473,7 @@ namespace ContractConfigurator.Parameters
                 if (dissassociateVesselsOnContractCompletion && !string.IsNullOrEmpty(define) && trackedVessel != null)
                 {
                     LoggingUtil.LogVerbose(this, "Removing defined vessel {0}", define);
+                    ContractVesselTracker.Instance.AssociateVessel(define, null);
                 }
 
                 if (!string.IsNullOrEmpty(defineList) && trackedVessel != null)


### PR DESCRIPTION
Looks like the line was deleted by mistake in [3a25a0344201b634cf4f79a4b028111d141633b5](https://github.com/KSP-RO/ContractConfigurator/commit/3a25a0344201b634cf4f79a4b028111d141633b5#diff-5a2a805a18a1a4dcc55c5a9d703ffe8eb53d79635cf8dcb7502edef7f2700106L436-R453). There's log line for it but no actual removal.