### PR TITLE
Add EITHER type to HasAntenna requirement

### DIFF
--- a/GameData/ContractConfigurator/Localization/en-us.cfg
+++ b/GameData/ContractConfigurator/Localization/en-us.cfg
@@ -249,6 +249,7 @@ Localization
         #cc.param.Docking.2 = Docked: <<1>> and <<2>>
         #cc.param.HasAntenna.transmit = Transmit antenna rating (combined): <<1>>
         #cc.param.HasAntenna.relay = Relay antenna rating (combined): <<1>>
+        #cc.param.HasAntenna.either = Antenna rating (combined): <<1>>
         #cc.param.HasCrew.unmanned = Unmanned
         // count, trait, experience
         #cc.param.HasCrew = Crew

--- a/GameData/ContractConfigurator/Localization/zh-cn.cfg
+++ b/GameData/ContractConfigurator/Localization/zh-cn.cfg
@@ -249,8 +249,9 @@ Localization
         #cc.param.CollectScience.recovery = 回收: <<1>>
         #cc.param.Docking.1 = 与目标对接: <<1>>
         #cc.param.Docking.2 = 对接: <<1>> 和 <<2>>
-        #cc.param.HasAntenna.transmit = 天线功耗(合并): <<1>>
+        #cc.param.HasAntenna.transmit = 直接天线功耗(合并): <<1>>
         #cc.param.HasAntenna.relay = 中继天线功耗(合并): <<1>>
+        #cc.param.HasAntenna.either = 天线功耗(合并): <<1>>
         #cc.param.HasCrew.unmanned = 无人驾驶
         // count, trait, experience
         #cc.param.HasCrew = 乘员

--- a/source/ContractConfigurator/Parameter/VesselParameter/HasAntenna.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/HasAntenna.cs
@@ -18,7 +18,8 @@ namespace ContractConfigurator.Parameters
         public enum AntennaType
 		{
 			RELAY,
-			TRANSMIT
+			TRANSMIT,
+			EITHER
 		};
 
 		protected double minAntennaPower { get; set; }
@@ -58,7 +59,12 @@ namespace ContractConfigurator.Parameters
                     countStr = Localizer.Format("#cc.param.count.between.num", KSPUtil.PrintSI(minAntennaPower, ""), KSPUtil.PrintSI(maxAntennaPower, ""));
                 }
 
-                this.title = Localizer.Format(antennaType == AntennaType.TRANSMIT ? "#cc.param.HasAntenna.transmit" : "#cc.param.HasAntenna.relay", countStr);
+                switch (antennaType)
+                {
+                    case AntennaType.RELAY: this.title = Localizer.Format("#cc.param.HasAntenna.relay", countStr); break;
+                    case AntennaType.TRANSMIT: this.title = Localizer.Format("#cc.param.HasAntenna.transmit", countStr); break;
+                    case AntennaType.EITHER: this.title = Localizer.Format("#cc.param.HasAntenna.either", countStr); break;
+                }
             }
             else
             {
@@ -108,14 +114,14 @@ namespace ContractConfigurator.Parameters
             double antennaPower = 0.0f;
             if (vessel.connection != null)
             {
-				if (antennaType == AntennaType.RELAY)
-				{
-					antennaPower = vessel.connection.Comm.antennaRelay.power;
-				}
-				else
-				{
-					antennaPower = vessel.connection.Comm.antennaTransmit.power;
-				}
+                double relayAntennaPower = vessel.connection.Comm.antennaRelay.power;
+                double transmitAntennaPower = vessel.connection.Comm.antennaTransmit.power;
+                switch (antennaType)
+                {
+                    case AntennaType.RELAY: antennaPower = relayAntennaPower; break;
+                    case AntennaType.TRANSMIT: antennaPower = transmitAntennaPower; break;
+                    case AntennaType.EITHER: antennaPower = Math.Max(relayAntennaPower, transmitAntennaPower); break;
+                }
             }
             return antennaPower >= minAntennaPower && antennaPower <= maxAntennaPower;
         }


### PR DESCRIPTION
`antennaTransmit` doesn't include relay antennas which is kinda surprising, at least in-game-mechanics wise.
This could be achieved with 2 HasAntenna nodes inside an Any node, but that's very verbose for a pretty common use case. 
As for the Chinese translation: I won't pretend to know Chinese, but from what I gather `#cc.param.HasAntenna.transmit` was referring to a generic antenna which transmit antenna is not.