### PR TITLE
Fix rotation of spawned vessels

### DIFF
--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -557,25 +557,13 @@ namespace ContractConfigurator.Behaviour
 
                     // Figure out the surface height and rotation
                     Quaternion normal = Quaternion.LookRotation(new Vector3((float)norm.x, (float)norm.y, (float)norm.z));
-                    Quaternion rotation = Quaternion.identity;
-                    float heading = vesselData.heading;
-                    if (shipConstruct == null)
-                    {
-                        rotation = rotation * Quaternion.FromToRotation(Vector3.up, Vector3.back);
-                    }
-                    else if (shipConstruct.shipFacility == EditorFacility.SPH)
-                    {
-                        rotation = rotation * Quaternion.FromToRotation(Vector3.forward, -Vector3.forward);
-                        heading += 180.0f;
-                    }
-                    else
-                    {
-                        rotation = rotation * Quaternion.FromToRotation(Vector3.up, Vector3.forward);
-                    }
+                    var rotation = Quaternion.Euler(vesselData.roll, vesselData.pitch, vesselData.heading);
 
-                    rotation = rotation * Quaternion.AngleAxis(vesselData.pitch, Vector3.right);
-                    rotation = rotation * Quaternion.AngleAxis(vesselData.roll, Vector3.down);
-                    rotation = rotation * Quaternion.AngleAxis(heading, Vector3.forward);
+                    rotation = rotation * Quaternion.AngleAxis(180, Vector3.up);
+                    if (shipConstruct?.shipFacility == EditorFacility.VAB)
+                    {
+                        rotation = rotation * Quaternion.FromToRotation(Vector3.forward, Vector3.up);
+                    }
 
                     // Set the height and rotation
                     if (landed || splashed)
@@ -584,7 +572,7 @@ namespace ContractConfigurator.Behaviour
                         hgt += vesselData.height;
                         protoVesselNode.SetValue("hgt", hgt.ToString());
                     }
-                    protoVesselNode.SetValue("rot", KSPUtil.WriteQuaternion(rotation * normal));
+                    protoVesselNode.SetValue("rot", KSPUtil.WriteQuaternion(normal * rotation));
 
                     // Set the normal vector relative to the surface
                     Vector3 nrm = (rotation * Vector3.forward);


### PR DESCRIPTION
Not sure how this is went unnoticed for so long, but the rotation of landed vessels created via `SpawnVessel` is completely bogus. 
With `heading`, `pitch` and `roll` set to 0 my craft was spawned on the side with a seemingly random heading.

At some point I tried to spawn a vessel with a clamp attached and it turned out to be very nice for debugging. Clamp allowed me to keep the rotation a given vessel was spawned with.

Anyway, `(0, 0, 0)` `heading`, `pitch` and `roll` before the fix:
![image](https://github.com/KSP-RO/ContractConfigurator/assets/1437195/26eb1a80-cd66-4551-a970-6b3d51f9ac9e)

The main problem, turns out, was the incorrect order of operations: `rotation * normal` -> `normal * rotation`. Changing that fixed the `(0, 0, 0)` case, but for non-zero it was still bogus.

The original code made a distinction between spawned part, the SPH and the VAB, and I'm not sure that's a good thing. Let's say I have a pod in the default orientation in the VAB, in the SPH, or spawned from a single part. If I then specify `heading` etc as `(h, p, r)` I expect the navball to point to `(h, p, r)` when I switch to said pod. I find it more natural than rotating VAB vessels 90 degrees up. On the other hand if we don't do that, then VAB vessels will spawn on their bellies by default.

For now I left the distinction and 90 degrees rotation for the VAB, so it shouldn't negatively affect legacy.