### PR TITLE
Fix a bug and add missing functionality relating to ExperienceTrait

### DIFF
--- a/source/ContractConfigurator/ExpressionParser/Parsers/Classes/ExperienceTraitParser.cs
+++ b/source/ContractConfigurator/ExpressionParser/Parsers/Classes/ExperienceTraitParser.cs
@@ -88,7 +88,7 @@ namespace ContractConfigurator.ExpressionParser
                 return true;
             }
 
-            return a.TypeName == b.TypeName;
+            return a?.TypeName == b?.TypeName;
         }
 
         public override ExperienceTrait ParseIdentifier(Token token)
@@ -110,17 +110,13 @@ namespace ContractConfigurator.ExpressionParser
                 return null;
             }
 
-            for (int index = 0; index < GameDatabase.Instance.ExperienceConfigs.Categories.Count; ++index)
+            var result = ConfigNodeUtil.ParseExperienceTrait(identifier);
+            if (result == null)
             {
-                if (identifier == GameDatabase.Instance.ExperienceConfigs.Categories[index].Name)
-                {
-                    Type type = KerbalRoster.GetExperienceTraitType(identifier) ?? typeof(ExperienceTrait);
-                    return ExperienceTrait.Create(type, GameDatabase.Instance.ExperienceConfigs.Categories[index], null);
-                }
+                LoggingUtil.LogError(this, StringBuilderCache.Format("Unknown experience trait '{0}'.", identifier));
             }
 
-            LoggingUtil.LogError(this, StringBuilderCache.Format("Unknown experience trait '{0}'.", identifier));
-            return null;
+            return result;
         }
     }
 }

--- a/source/ContractConfigurator/ScenarioModules/PersistentDataStore.cs
+++ b/source/ContractConfigurator/ScenarioModules/PersistentDataStore.cs
@@ -245,6 +245,10 @@ namespace ContractConfigurator
                 Biome b = (Biome)value;
                 strValue = b.body.name + ";" + b.biome;
             }
+            else if (type == typeof(Experience.ExperienceTrait))
+            {
+                strValue = ((Experience.ExperienceTrait)(value)).TypeName;
+            }
             else if (type.Name == "List`1")
             {
                 strValue = "[ ";

--- a/source/ContractConfigurator/Util/ConfigNodeUtil.cs
+++ b/source/ContractConfigurator/Util/ConfigNodeUtil.cs
@@ -394,6 +394,10 @@ namespace ContractConfigurator
             {
                 value = (T)(object)ParseLaunchSiteValue(stringValue);
             }
+            else if (typeof(T) == typeof(Experience.ExperienceTrait))
+            {
+                value = (T)(object)ParseExperienceTrait(stringValue);
+            }
             // Do newline conversions
             else if (typeof(T) == typeof(string))
             {
@@ -1067,6 +1071,20 @@ namespace ContractConfigurator
                 if (pcm.name == name)
                 {
                     return pcm;
+                }
+            }
+
+            return null;
+        }
+
+        public static Experience.ExperienceTrait ParseExperienceTrait(string traitName)
+        {
+            for (int index = 0; index < GameDatabase.Instance.ExperienceConfigs.Categories.Count; ++index)
+            {
+                if (traitName == GameDatabase.Instance.ExperienceConfigs.Categories[index].Name)
+                {
+                    Type type = KerbalRoster.GetExperienceTraitType(traitName) ?? typeof(Experience.ExperienceTrait);
+                    return Experience.ExperienceTrait.Create(type, GameDatabase.Instance.ExperienceConfigs.Categories[index], null);
                 }
             }
 


### PR DESCRIPTION
There was a missing null-check in `EQ`.
Other than that: `UNIQUE_DATA` was unable to handle `ExperienceTrait` at all.