### PR TITLE
Add support for generating waypoints centered on vessels

### DIFF
--- a/source/ContractConfigurator/ExpressionParser/Parsers/Behaviours/WaypointGeneratorParser.cs
+++ b/source/ContractConfigurator/ExpressionParser/Parsers/Behaviours/WaypointGeneratorParser.cs
@@ -84,7 +84,6 @@ namespace ContractConfigurator.ExpressionParser
                     }
                     else
                     {
-                        yield return "nearIndex";
                         yield return "minDistance";
                         yield return "maxDistance";
                     }


### PR DESCRIPTION
`WaypointGenerator` with type `RANDOM_WAYPOINT_NEAR` now has new parameter `vessel` which conflicts with `nearIndex`. `vessel` is the name that gets defined in a VPG with the `define` keyword.