### PR TITLE
Add more Conditions to the SpawnVessel Behavior

### DIFF
--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -104,7 +104,6 @@ namespace ContractConfigurator.Behaviour
         }
         private List<VesselData> vessels = new List<VesselData>();
         private bool vesselsCreated = false;
-        private bool deferVesselCreation = false; // deferVesselCreation is deprecated and is retained only as a dummy variable
         private bool switchToTrackingStation = false;
 
         public int KerbalCount
@@ -159,8 +158,8 @@ namespace ContractConfigurator.Behaviour
         public static SpawnVessel Create(ConfigNode configNode, SpawnVesselFactory factory)
         {
             SpawnVessel spawnVessel = new SpawnVessel();
-            // deferVesselCreation is deprecated and is retained only as a dummy variable
-            ConfigNodeUtil.ParseValue<bool>(configNode, "deferVesselCreation", x => spawnVessel.deferVesselCreation = x, factory, false);
+            bool dummy = false;
+            ConfigNodeUtil.ParseValue<bool>(configNode, "deferVesselCreation", x => dummy = x, factory, false); // deferVesselCreation is deprecated
             ConfigNodeUtil.ParseValue<bool>(configNode, "switchToTrackingStation", x => spawnVessel.switchToTrackingStation = x, factory, false);
 
             foreach (ConfigNode child in configNode.GetNodes("CONDITION"))

--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -445,7 +445,7 @@ namespace ContractConfigurator.Behaviour
                         // Add the crew member
                         if (part != null)
                         {
-                            ProtoCrewMember crewMember = HighLogic.CurrentGame.CrewRoster.AllKerbals().Where(cm => cm.name == cd.name).FirstOrDefault<ProtoCrewMember>();
+                            ProtoCrewMember crewMember = HighLogic.CurrentGame.CrewRoster.AllKerbals().Where(cm => cm.name == cd.name && cm.rosterStatus == ProtoCrewMember.RosterStatus.Available).FirstOrDefault<ProtoCrewMember>();
                             // Create the ProtoCrewMember if does not exist
                             if (crewMember == null || crewMember.name != cd.name)
                             {

--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -104,7 +104,7 @@ namespace ContractConfigurator.Behaviour
         }
         private List<VesselData> vessels = new List<VesselData>();
         private bool vesselsCreated = false;
-        private bool deferVesselCreation = false;
+        private bool deferVesselCreation = false; // deferVesselCreation is deprecated and is retained only as a dummy variable
         private bool switchToTrackingStation = false;
 
         public int KerbalCount
@@ -123,7 +123,6 @@ namespace ContractConfigurator.Behaviour
         /// <param name="orig"></param>
         public SpawnVessel(List<ConditionDetail> conditions, SpawnVessel orig)
         {
-            deferVesselCreation = orig.deferVesselCreation;
             switchToTrackingStation = orig.switchToTrackingStation;
             this.conditions = conditions;
 
@@ -160,7 +159,7 @@ namespace ContractConfigurator.Behaviour
         public static SpawnVessel Create(ConfigNode configNode, SpawnVesselFactory factory)
         {
             SpawnVessel spawnVessel = new SpawnVessel();
-
+            // deferVesselCreation is deprecated and is retained only as a dummy variable
             ConfigNodeUtil.ParseValue<bool>(configNode, "deferVesselCreation", x => spawnVessel.deferVesselCreation = x, factory, false);
             ConfigNodeUtil.ParseValue<bool>(configNode, "switchToTrackingStation", x => spawnVessel.switchToTrackingStation = x, factory, false);
 
@@ -647,7 +646,6 @@ namespace ContractConfigurator.Behaviour
         {
             base.OnSave(configNode);
             configNode.AddValue("vesselsCreated", vesselsCreated);
-            configNode.AddValue("deferVesselCreation", deferVesselCreation);
             configNode.AddValue("switchToTrackingStation", switchToTrackingStation);
             foreach (ConditionDetail cd in conditions)
             {
@@ -726,7 +724,6 @@ namespace ContractConfigurator.Behaviour
         {
             base.OnLoad(configNode);
             vesselsCreated = ConfigNodeUtil.ParseValue<bool>(configNode, "vesselsCreated");
-            deferVesselCreation = ConfigNodeUtil.ParseValue<bool?>(configNode, "deferVesselCreation", (bool?)false).Value;
             switchToTrackingStation = ConfigNodeUtil.ParseValue<bool?>(configNode, "switchToTrackingStation", (bool?)false).Value;
 
             foreach (ConfigNode child in configNode.GetNodes("CONDITION"))

--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -7,7 +7,6 @@ using KSP;
 using Contracts;
 using ContractConfigurator;
 using ContractConfigurator.ExpressionParser;
-using UnityEngine.SceneManagement;
 
 namespace ContractConfigurator.Behaviour
 {
@@ -42,6 +41,7 @@ namespace ContractConfigurator.Behaviour
             public bool addToRoster = true;
 
             public CrewData() { }
+
             public CrewData(CrewData cd)
             {
                 name = cd.name;
@@ -105,7 +105,7 @@ namespace ContractConfigurator.Behaviour
         private List<VesselData> vessels = new List<VesselData>();
         private bool vesselsCreated = false;
         private bool deferVesselCreation = false;
-        private bool switchtoTrackingStation = false;
+        private bool switchToTrackingStation = false;
 
         public int KerbalCount
         {
@@ -124,7 +124,7 @@ namespace ContractConfigurator.Behaviour
         public SpawnVessel(List<ConditionDetail> conditions, SpawnVessel orig)
         {
             deferVesselCreation = orig.deferVesselCreation;
-            switchtoTrackingStation = orig.switchtoTrackingStation;
+            switchToTrackingStation = orig.switchToTrackingStation;
             this.conditions = conditions;
 
             foreach (VesselData vessel in orig.vessels)
@@ -162,7 +162,7 @@ namespace ContractConfigurator.Behaviour
             SpawnVessel spawnVessel = new SpawnVessel();
 
             ConfigNodeUtil.ParseValue<bool>(configNode, "deferVesselCreation", x => spawnVessel.deferVesselCreation = x, factory, false);
-            ConfigNodeUtil.ParseValue<bool>(configNode, "switchtoTrackingStation", x => spawnVessel.switchtoTrackingStation = x, factory, false);
+            ConfigNodeUtil.ParseValue<bool>(configNode, "switchToTrackingStation", x => spawnVessel.switchToTrackingStation = x, factory, false);
 
             foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
             {
@@ -317,7 +317,7 @@ namespace ContractConfigurator.Behaviour
             }
 
             // Some vessels will fail to spawn if in Flight and running certain part modules with background processing
-            if (switchtoTrackingStation && HighLogic.LoadedScene == GameScenes.FLIGHT)
+            if (switchToTrackingStation && HighLogic.LoadedScene == GameScenes.FLIGHT)
             {
                 GamePersistence.SaveGame("persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
                 HighLogic.LoadScene(GameScenes.TRACKSTATION);
@@ -648,7 +648,7 @@ namespace ContractConfigurator.Behaviour
             base.OnSave(configNode);
             configNode.AddValue("vesselsCreated", vesselsCreated);
             configNode.AddValue("deferVesselCreation", deferVesselCreation);
-            configNode.AddValue("switchtoTrackingStation", switchtoTrackingStation);
+            configNode.AddValue("switchToTrackingStation", switchToTrackingStation);
             foreach (ConditionDetail cd in conditions)
             {
                 ConfigNode child = new ConfigNode("CONDITION");
@@ -727,7 +727,7 @@ namespace ContractConfigurator.Behaviour
             base.OnLoad(configNode);
             vesselsCreated = ConfigNodeUtil.ParseValue<bool>(configNode, "vesselsCreated");
             deferVesselCreation = ConfigNodeUtil.ParseValue<bool?>(configNode, "deferVesselCreation", (bool?)false).Value;
-            switchtoTrackingStation = ConfigNodeUtil.ParseValue<bool?>(configNode, "switchtoTrackingStation", (bool?)false).Value;
+            switchToTrackingStation = ConfigNodeUtil.ParseValue<bool?>(configNode, "switchToTrackingStation", (bool?)false).Value;
 
             foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
             {
@@ -845,9 +845,10 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnAccepted()
         {
-            foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_ACCEPTED))
-                CreateVessels();
-            if (conditions.Count == 0)
+            if (conditions.Count > 0)
+                foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_ACCEPTED))
+                    CreateVessels();
+            else
                 CreateVessels();
         }
 

--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -104,7 +104,6 @@ namespace ContractConfigurator.Behaviour
         }
         private List<VesselData> vessels = new List<VesselData>();
         private bool vesselsCreated = false;
-        private bool switchToTrackingStation = false;
 
         public int KerbalCount
         {
@@ -122,7 +121,6 @@ namespace ContractConfigurator.Behaviour
         /// <param name="orig"></param>
         public SpawnVessel(List<ConditionDetail> conditions, SpawnVessel orig)
         {
-            switchToTrackingStation = orig.switchToTrackingStation;
             this.conditions = conditions;
 
             foreach (VesselData vessel in orig.vessels)
@@ -160,7 +158,6 @@ namespace ContractConfigurator.Behaviour
             SpawnVessel spawnVessel = new SpawnVessel();
             bool dummy = false;
             ConfigNodeUtil.ParseValue<bool>(configNode, "deferVesselCreation", x => dummy = x, factory, false); // deferVesselCreation is deprecated
-            ConfigNodeUtil.ParseValue<bool>(configNode, "switchToTrackingStation", x => spawnVessel.switchToTrackingStation = x, factory, false);
 
             foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
             {
@@ -312,13 +309,6 @@ namespace ContractConfigurator.Behaviour
             if (vesselsCreated)
             {
                 return false;
-            }
-
-            // Some vessels will fail to spawn if in Flight and running certain part modules with background processing
-            if (switchToTrackingStation && HighLogic.LoadedScene == GameScenes.FLIGHT)
-            {
-                GamePersistence.SaveGame("persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
-                HighLogic.LoadScene(GameScenes.TRACKSTATION);
             }
 
             String gameDataDir = KSPUtil.ApplicationRootPath;
@@ -645,7 +635,6 @@ namespace ContractConfigurator.Behaviour
         {
             base.OnSave(configNode);
             configNode.AddValue("vesselsCreated", vesselsCreated);
-            configNode.AddValue("switchToTrackingStation", switchToTrackingStation);
             foreach (ConditionDetail cd in conditions)
             {
                 ConfigNode child = new ConfigNode("CONDITION");
@@ -723,7 +712,6 @@ namespace ContractConfigurator.Behaviour
         {
             base.OnLoad(configNode);
             vesselsCreated = ConfigNodeUtil.ParseValue<bool>(configNode, "vesselsCreated");
-            switchToTrackingStation = ConfigNodeUtil.ParseValue<bool?>(configNode, "switchToTrackingStation", (bool?)false).Value;
 
             foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
             {

--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -7,6 +7,7 @@ using KSP;
 using Contracts;
 using ContractConfigurator;
 using ContractConfigurator.ExpressionParser;
+using UnityEngine.SceneManagement;
 
 namespace ContractConfigurator.Behaviour
 {
@@ -15,7 +16,26 @@ namespace ContractConfigurator.Behaviour
     /// </summary>
     public class SpawnVessel : ContractBehaviour, IHasKerbalBehaviour, IKerbalNameStorage
     {
-        private class CrewData
+		public class ConditionDetail
+		{
+			public enum Condition
+			{
+				CONTRACT_ACCEPTED,
+				CONTRACT_FAILED,
+				CONTRACT_SUCCESS,
+				CONTRACT_COMPLETED,
+				PARAMETER_FAILED,
+				PARAMETER_COMPLETED
+			}
+
+			public Condition condition;
+			public string parameter;
+		}
+
+		protected List<ConditionDetail> conditions = new List<ConditionDetail>();
+        protected SpawnVessel spawnVessel;
+
+		private class CrewData
         {
             public string name = null;
             public ProtoCrewMember.Gender? gender = null;
@@ -85,8 +105,9 @@ namespace ContractConfigurator.Behaviour
         private List<VesselData> vessels = new List<VesselData>();
         private bool vesselsCreated = false;
         private bool deferVesselCreation = false;
+		private bool switchtoTrackingStation = false;
 
-        public int KerbalCount
+		public int KerbalCount
         {
             get
             {
@@ -100,10 +121,13 @@ namespace ContractConfigurator.Behaviour
         /// Copy Constructor.
         /// </summary>
         /// <param name="orig"></param>
-        public SpawnVessel(SpawnVessel orig)
+        public SpawnVessel(List<ConditionDetail> conditions, SpawnVessel orig)
         {
             deferVesselCreation = orig.deferVesselCreation;
-            foreach (VesselData vessel in orig.vessels)
+			switchtoTrackingStation = orig.switchtoTrackingStation;
+			this.conditions = conditions;
+
+			foreach (VesselData vessel in orig.vessels)
             {
                 if (vessel.pqsCity != null)
                 {
@@ -138,8 +162,16 @@ namespace ContractConfigurator.Behaviour
             SpawnVessel spawnVessel = new SpawnVessel();
 
             ConfigNodeUtil.ParseValue<bool>(configNode, "deferVesselCreation", x => spawnVessel.deferVesselCreation = x, factory, false);
+			ConfigNodeUtil.ParseValue<bool>(configNode, "switchtoTrackingStation", x => spawnVessel.switchtoTrackingStation = x, factory, false);
 
-            bool valid = true;
+			foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
+			{
+				ConditionDetail cd = new ConditionDetail();
+				ConfigNodeUtil.ParseValue<ConditionDetail.Condition>(configNode, "condition", x => cd.condition = x, factory, ConditionDetail.Condition.CONTRACT_COMPLETED);
+				ConfigNodeUtil.ParseValue<string>(configNode, "parameter", x => cd.parameter = x, factory, (string)null);
+			}
+
+			bool valid = true;
             int index = 0;
             foreach (ConfigNode child in ConfigNodeUtil.GetChildNodes(configNode, "VESSEL"))
             {
@@ -278,12 +310,16 @@ namespace ContractConfigurator.Behaviour
 
         protected bool CreateVessels()
         {
-            if (vesselsCreated)
+			if (vesselsCreated)
             {
-                return false;
+				return false;
             }
 
-            String gameDataDir = KSPUtil.ApplicationRootPath;
+			// Some vessels will fail to spawn if in Flight and running certain part modules with background processing
+			if (switchtoTrackingStation && HighLogic.LoadedScene == GameScenes.FLIGHT)
+			    HighLogic.LoadScene(GameScenes.TRACKSTATION);
+
+			String gameDataDir = KSPUtil.ApplicationRootPath;
             gameDataDir = gameDataDir.Replace("\\", "/");
             if (!gameDataDir.EndsWith("/"))
             {
@@ -294,11 +330,11 @@ namespace ContractConfigurator.Behaviour
             // Spawn the vessel in the game world
             foreach (VesselData vesselData in vessels)
             {
-                LoggingUtil.LogVerbose(this, "Spawning a vessel named '{0}'", vesselData.name);
+				LoggingUtil.LogVerbose(this, "Spawning a vessel named '{0}'", vesselData.name);
 
                 // Set additional info for landed vessels
                 bool landed = false;
-                if (!vesselData.orbiting)
+				if (!vesselData.orbiting)
                 {
                     landed = true;
                     if (vesselData.altitude == null)
@@ -585,6 +621,7 @@ namespace ContractConfigurator.Behaviour
                 ProtoVessel protoVessel = new ProtoVessel(protoVesselNode, HighLogic.CurrentGame);
                 protoVessel.Load(HighLogic.CurrentGame.flightState);
 
+
                 // Store the id for later use
                 vesselData.id = protoVessel.vesselRef.id;
 
@@ -593,7 +630,9 @@ namespace ContractConfigurator.Behaviour
             }
 
             vesselsCreated = true;
-            return true;
+			// After the vessels are created, save the game again so we don't lose our changes
+			GamePersistence.SaveGame("persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
+			return true;
         }
 
         protected override void OnSave(ConfigNode configNode)
@@ -601,8 +640,20 @@ namespace ContractConfigurator.Behaviour
             base.OnSave(configNode);
             configNode.AddValue("vesselsCreated", vesselsCreated);
             configNode.AddValue("deferVesselCreation", deferVesselCreation);
+			configNode.AddValue("switchtoTrackingStation", switchtoTrackingStation);
+			foreach (ConditionDetail cd in conditions)
+			{
+				ConfigNode child = new ConfigNode("CONDITION");
+				configNode.AddNode(child);
 
-            foreach (VesselData vd in vessels)
+				child.AddValue("condition", cd.condition);
+				if (!string.IsNullOrEmpty(cd.parameter))
+				{
+					child.AddValue("parameter", cd.parameter);
+				}
+			}
+
+			foreach (VesselData vd in vessels)
             {
                 ConfigNode child = new ConfigNode("VESSEL_DETAIL");
 
@@ -664,11 +715,20 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnLoad(ConfigNode configNode)
         {
-            base.OnLoad(configNode);
+			base.OnLoad(configNode);
             vesselsCreated = ConfigNodeUtil.ParseValue<bool>(configNode, "vesselsCreated");
             deferVesselCreation = ConfigNodeUtil.ParseValue<bool?>(configNode, "deferVesselCreation", (bool?)false).Value;
+			switchtoTrackingStation = ConfigNodeUtil.ParseValue<bool?>(configNode, "switchtoTrackingStation", (bool?)false).Value;
 
-            foreach (ConfigNode child in configNode.GetNodes("VESSEL_DETAIL"))
+			foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
+			{
+				ConditionDetail cd = new ConditionDetail();
+				cd.condition = ConfigNodeUtil.ParseValue<ConditionDetail.Condition>(child, "condition");
+				cd.parameter = ConfigNodeUtil.ParseValue<string>(child, "parameter", (string)null);
+				conditions.Add(cd);
+			}
+
+			foreach (ConfigNode child in configNode.GetNodes("VESSEL_DETAIL"))
             {
                 // Read all the orbit data
                 VesselData vd = new VesselData();
@@ -712,13 +772,11 @@ namespace ContractConfigurator.Behaviour
         protected override void OnRegister()
         {
             GameEvents.onVesselRecovered.Add(OnVesselRecovered);
-            GameEvents.onGameSceneLoadRequested.Add(OnGameSceneLoad);
         }
 
         protected override void OnUnregister()
         {
             GameEvents.onVesselRecovered.Remove(OnVesselRecovered);
-            GameEvents.onGameSceneLoadRequested.Remove(OnGameSceneLoad);
         }
 
         private void OnVesselRecovered(ProtoVessel v, bool quick)
@@ -775,27 +833,42 @@ namespace ContractConfigurator.Behaviour
             }
         }
 
-        private void OnGameSceneLoad(GameScenes gameScene)
-        {
-            if (deferVesselCreation && (gameScene == GameScenes.FLIGHT || gameScene == GameScenes.TRACKSTATION || gameScene == GameScenes.EDITOR))
-            {
-                if (CreateVessels())
-                {
-                    // After the vessels are created, save the game again so we don't lose our changes
-                    GamePersistence.SaveGame("persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
-                }
-            }
-        }
-
         protected override void OnAccepted()
         {
-            if (!deferVesselCreation)
-            {
+			foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_ACCEPTED))
+				CreateVessels();
+			if (conditions.Count == 0)
                 CreateVessels();
-            }
         }
 
-        protected override void OnCancelled()
+		protected override void OnCompleted()
+		{
+			foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_COMPLETED || cd.condition == ConditionDetail.Condition.CONTRACT_SUCCESS))
+				CreateVessels();
+		}
+
+		protected override void OnFailed()
+		{
+			foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_FAILED))
+				CreateVessels();
+		}
+
+		protected override void OnParameterStateChange(ContractParameter param)
+		{
+			if (param.State == ParameterState.Incomplete)
+			{
+				return;
+			}
+			ConditionDetail.Condition cond = param.State == ParameterState.Complete ?
+				ConditionDetail.Condition.PARAMETER_COMPLETED :
+				ConditionDetail.Condition.PARAMETER_FAILED;
+
+			LoggingUtil.LogDebug(this, "OnParameterStateChange() Triggered on " + param.ID + ":" + param.State);
+			foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == cond && cd.parameter == param.ID))
+				CreateVessels();
+		}
+
+		protected override void OnCancelled()
         {
             RemoveVessels();
         }
@@ -812,7 +885,7 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnGenerateFailed()
         {
-            RemoveVessels();
+			RemoveVessels();
         }
 
         protected override void OnOfferExpired()
@@ -827,9 +900,9 @@ namespace ContractConfigurator.Behaviour
 
         private void RemoveVessels()
         {
-            foreach (VesselData vd in vessels)
+			foreach (VesselData vd in vessels)
             {
-                Vessel vessel = FlightGlobals.Vessels.Find(v => v != null && v.id == vd.id);
+				Vessel vessel = FlightGlobals.Vessels.Find(v => v != null && v.id == vd.id);
                 if (vessel != null)
                 {
                     vessel.state = Vessel.State.DEAD;

--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -318,7 +318,10 @@ namespace ContractConfigurator.Behaviour
 
             // Some vessels will fail to spawn if in Flight and running certain part modules with background processing
             if (switchtoTrackingStation && HighLogic.LoadedScene == GameScenes.FLIGHT)
+            {
+                GamePersistence.SaveGame("persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
                 HighLogic.LoadScene(GameScenes.TRACKSTATION);
+            }
 
             String gameDataDir = KSPUtil.ApplicationRootPath;
             gameDataDir = gameDataDir.Replace("\\", "/");

--- a/source/ContractConfigurator/Behaviour/SpawnVessel.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnVessel.cs
@@ -16,26 +16,26 @@ namespace ContractConfigurator.Behaviour
     /// </summary>
     public class SpawnVessel : ContractBehaviour, IHasKerbalBehaviour, IKerbalNameStorage
     {
-		public class ConditionDetail
-		{
-			public enum Condition
-			{
-				CONTRACT_ACCEPTED,
-				CONTRACT_FAILED,
-				CONTRACT_SUCCESS,
-				CONTRACT_COMPLETED,
-				PARAMETER_FAILED,
-				PARAMETER_COMPLETED
-			}
+        public class ConditionDetail
+        {
+            public enum Condition
+            {
+                CONTRACT_ACCEPTED,
+                CONTRACT_FAILED,
+                CONTRACT_SUCCESS,
+                CONTRACT_COMPLETED,
+                PARAMETER_FAILED,
+                PARAMETER_COMPLETED
+            }
 
-			public Condition condition;
-			public string parameter;
-		}
+            public Condition condition;
+            public string parameter;
+        }
 
-		protected List<ConditionDetail> conditions = new List<ConditionDetail>();
+        protected List<ConditionDetail> conditions = new List<ConditionDetail>();
         protected SpawnVessel spawnVessel;
 
-		private class CrewData
+        private class CrewData
         {
             public string name = null;
             public ProtoCrewMember.Gender? gender = null;
@@ -105,9 +105,9 @@ namespace ContractConfigurator.Behaviour
         private List<VesselData> vessels = new List<VesselData>();
         private bool vesselsCreated = false;
         private bool deferVesselCreation = false;
-		private bool switchtoTrackingStation = false;
+        private bool switchtoTrackingStation = false;
 
-		public int KerbalCount
+        public int KerbalCount
         {
             get
             {
@@ -124,10 +124,10 @@ namespace ContractConfigurator.Behaviour
         public SpawnVessel(List<ConditionDetail> conditions, SpawnVessel orig)
         {
             deferVesselCreation = orig.deferVesselCreation;
-			switchtoTrackingStation = orig.switchtoTrackingStation;
-			this.conditions = conditions;
+            switchtoTrackingStation = orig.switchtoTrackingStation;
+            this.conditions = conditions;
 
-			foreach (VesselData vessel in orig.vessels)
+            foreach (VesselData vessel in orig.vessels)
             {
                 if (vessel.pqsCity != null)
                 {
@@ -162,16 +162,16 @@ namespace ContractConfigurator.Behaviour
             SpawnVessel spawnVessel = new SpawnVessel();
 
             ConfigNodeUtil.ParseValue<bool>(configNode, "deferVesselCreation", x => spawnVessel.deferVesselCreation = x, factory, false);
-			ConfigNodeUtil.ParseValue<bool>(configNode, "switchtoTrackingStation", x => spawnVessel.switchtoTrackingStation = x, factory, false);
+            ConfigNodeUtil.ParseValue<bool>(configNode, "switchtoTrackingStation", x => spawnVessel.switchtoTrackingStation = x, factory, false);
 
-			foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
-			{
-				ConditionDetail cd = new ConditionDetail();
-				ConfigNodeUtil.ParseValue<ConditionDetail.Condition>(configNode, "condition", x => cd.condition = x, factory, ConditionDetail.Condition.CONTRACT_COMPLETED);
-				ConfigNodeUtil.ParseValue<string>(configNode, "parameter", x => cd.parameter = x, factory, (string)null);
-			}
+            foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
+            {
+                ConditionDetail cd = new ConditionDetail();
+                ConfigNodeUtil.ParseValue<ConditionDetail.Condition>(configNode, "condition", x => cd.condition = x, factory, ConditionDetail.Condition.CONTRACT_COMPLETED);
+                ConfigNodeUtil.ParseValue<string>(configNode, "parameter", x => cd.parameter = x, factory, (string)null);
+            }
 
-			bool valid = true;
+            bool valid = true;
             int index = 0;
             foreach (ConfigNode child in ConfigNodeUtil.GetChildNodes(configNode, "VESSEL"))
             {
@@ -272,7 +272,8 @@ namespace ContractConfigurator.Behaviour
                             CrewData cd = new CrewData();
 
                             // Read crew details
-                            valid &= ConfigNodeUtil.ParseValue<string>(crewNode, "name", x => cd.name = x, factory, (string)null);
+                            valid &= ConfigNodeUtil.ParseValue<string>(crewNode, "name", x => cd.name = x, factory, (string)null); 
+                            valid &= ConfigNodeUtil.ParseValue<ProtoCrewMember.Gender>(crewNode, "gender", x => cd.gender = x, factory, 0);
                             valid &= ConfigNodeUtil.ParseValue<bool>(crewNode, "addToRoster", x => cd.addToRoster = x, factory, true);
 
                             // Check for unexpected values
@@ -310,16 +311,16 @@ namespace ContractConfigurator.Behaviour
 
         protected bool CreateVessels()
         {
-			if (vesselsCreated)
+            if (vesselsCreated)
             {
-				return false;
+                return false;
             }
 
-			// Some vessels will fail to spawn if in Flight and running certain part modules with background processing
-			if (switchtoTrackingStation && HighLogic.LoadedScene == GameScenes.FLIGHT)
-			    HighLogic.LoadScene(GameScenes.TRACKSTATION);
+            // Some vessels will fail to spawn if in Flight and running certain part modules with background processing
+            if (switchtoTrackingStation && HighLogic.LoadedScene == GameScenes.FLIGHT)
+                HighLogic.LoadScene(GameScenes.TRACKSTATION);
 
-			String gameDataDir = KSPUtil.ApplicationRootPath;
+            String gameDataDir = KSPUtil.ApplicationRootPath;
             gameDataDir = gameDataDir.Replace("\\", "/");
             if (!gameDataDir.EndsWith("/"))
             {
@@ -330,11 +331,11 @@ namespace ContractConfigurator.Behaviour
             // Spawn the vessel in the game world
             foreach (VesselData vesselData in vessels)
             {
-				LoggingUtil.LogVerbose(this, "Spawning a vessel named '{0}'", vesselData.name);
+                LoggingUtil.LogVerbose(this, "Spawning a vessel named '{0}'", vesselData.name);
 
                 // Set additional info for landed vessels
                 bool landed = false;
-				if (!vesselData.orbiting)
+                if (!vesselData.orbiting)
                 {
                     landed = true;
                     if (vesselData.altitude == null)
@@ -444,17 +445,21 @@ namespace ContractConfigurator.Behaviour
                         // Add the crew member
                         if (part != null)
                         {
-                            // Create the ProtoCrewMember
-                            ProtoCrewMember crewMember = HighLogic.CurrentGame.CrewRoster.GetNewKerbal(ProtoCrewMember.KerbalType.Unowned);
-                            if (cd.gender != null)
+                            ProtoCrewMember crewMember = HighLogic.CurrentGame.CrewRoster.AllKerbals().Where(cm => cm.name == cd.name).FirstOrDefault<ProtoCrewMember>();
+                            // Create the ProtoCrewMember if does not exist
+                            if (crewMember == null || crewMember.name != cd.name)
                             {
-                                crewMember.gender = cd.gender.Value;
+                                crewMember = HighLogic.CurrentGame.CrewRoster.GetNewKerbal(ProtoCrewMember.KerbalType.Unowned);
+                                if (cd.gender != null)
+                                {
+                                    crewMember.gender = cd.gender.Value;
+                                }
+                                if (cd.name != null)
+                                {
+                                    crewMember.ChangeName(cd.name);
+                                }
                             }
-                            if (cd.name != null)
-                            {
-                                crewMember.ChangeName(cd.name);
-                            }
-
+                            
                             // Add them to the part
                             success = part.AddCrewmemberAt(crewMember, part.protoModuleCrew.Count);
                         }
@@ -630,9 +635,9 @@ namespace ContractConfigurator.Behaviour
             }
 
             vesselsCreated = true;
-			// After the vessels are created, save the game again so we don't lose our changes
-			GamePersistence.SaveGame("persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
-			return true;
+            // After the vessels are created, save the game again so we don't lose our changes
+            GamePersistence.SaveGame("persistent", HighLogic.SaveFolder, SaveMode.OVERWRITE);
+            return true;
         }
 
         protected override void OnSave(ConfigNode configNode)
@@ -640,20 +645,20 @@ namespace ContractConfigurator.Behaviour
             base.OnSave(configNode);
             configNode.AddValue("vesselsCreated", vesselsCreated);
             configNode.AddValue("deferVesselCreation", deferVesselCreation);
-			configNode.AddValue("switchtoTrackingStation", switchtoTrackingStation);
-			foreach (ConditionDetail cd in conditions)
-			{
-				ConfigNode child = new ConfigNode("CONDITION");
-				configNode.AddNode(child);
+            configNode.AddValue("switchtoTrackingStation", switchtoTrackingStation);
+            foreach (ConditionDetail cd in conditions)
+            {
+                ConfigNode child = new ConfigNode("CONDITION");
+                configNode.AddNode(child);
 
-				child.AddValue("condition", cd.condition);
-				if (!string.IsNullOrEmpty(cd.parameter))
-				{
-					child.AddValue("parameter", cd.parameter);
-				}
-			}
+                child.AddValue("condition", cd.condition);
+                if (!string.IsNullOrEmpty(cd.parameter))
+                {
+                    child.AddValue("parameter", cd.parameter);
+                }
+            }
 
-			foreach (VesselData vd in vessels)
+            foreach (VesselData vd in vessels)
             {
                 ConfigNode child = new ConfigNode("VESSEL_DETAIL");
 
@@ -704,6 +709,7 @@ namespace ContractConfigurator.Behaviour
                     {
                         crewNode.AddValue("name", cd.name);
                     }
+                    crewNode.AddValue("gender", cd.gender);
                     crewNode.AddValue("addToRoster", cd.addToRoster);
 
                     child.AddNode(crewNode);
@@ -715,20 +721,20 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnLoad(ConfigNode configNode)
         {
-			base.OnLoad(configNode);
+            base.OnLoad(configNode);
             vesselsCreated = ConfigNodeUtil.ParseValue<bool>(configNode, "vesselsCreated");
             deferVesselCreation = ConfigNodeUtil.ParseValue<bool?>(configNode, "deferVesselCreation", (bool?)false).Value;
-			switchtoTrackingStation = ConfigNodeUtil.ParseValue<bool?>(configNode, "switchtoTrackingStation", (bool?)false).Value;
+            switchtoTrackingStation = ConfigNodeUtil.ParseValue<bool?>(configNode, "switchtoTrackingStation", (bool?)false).Value;
 
-			foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
-			{
-				ConditionDetail cd = new ConditionDetail();
-				cd.condition = ConfigNodeUtil.ParseValue<ConditionDetail.Condition>(child, "condition");
-				cd.parameter = ConfigNodeUtil.ParseValue<string>(child, "parameter", (string)null);
-				conditions.Add(cd);
-			}
+            foreach (ConfigNode child in configNode.GetNodes("CONDITION"))
+            {
+                ConditionDetail cd = new ConditionDetail();
+                cd.condition = ConfigNodeUtil.ParseValue<ConditionDetail.Condition>(child, "condition");
+                cd.parameter = ConfigNodeUtil.ParseValue<string>(child, "parameter", (string)null);
+                conditions.Add(cd);
+            }
 
-			foreach (ConfigNode child in configNode.GetNodes("VESSEL_DETAIL"))
+            foreach (ConfigNode child in configNode.GetNodes("VESSEL_DETAIL"))
             {
                 // Read all the orbit data
                 VesselData vd = new VesselData();
@@ -759,6 +765,7 @@ namespace ContractConfigurator.Behaviour
                     CrewData cd = new CrewData();
 
                     cd.name = ConfigNodeUtil.ParseValue<string>(crewNode, "name", (string)null);
+                    cd.gender = ConfigNodeUtil.ParseValue<ProtoCrewMember.Gender>(crewNode, "gender", 0);
                     cd.addToRoster = ConfigNodeUtil.ParseValue<bool>(crewNode, "addToRoster");
 
                     vd.crew.Add(cd);
@@ -835,40 +842,40 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnAccepted()
         {
-			foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_ACCEPTED))
-				CreateVessels();
-			if (conditions.Count == 0)
+            foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_ACCEPTED))
+                CreateVessels();
+            if (conditions.Count == 0)
                 CreateVessels();
         }
 
-		protected override void OnCompleted()
-		{
-			foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_COMPLETED || cd.condition == ConditionDetail.Condition.CONTRACT_SUCCESS))
-				CreateVessels();
-		}
+        protected override void OnCompleted()
+        {
+            foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_COMPLETED || cd.condition == ConditionDetail.Condition.CONTRACT_SUCCESS))
+                CreateVessels();
+        }
 
-		protected override void OnFailed()
-		{
-			foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_FAILED))
-				CreateVessels();
-		}
+        protected override void OnFailed()
+        {
+            foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == ConditionDetail.Condition.CONTRACT_FAILED))
+                CreateVessels();
+        }
 
-		protected override void OnParameterStateChange(ContractParameter param)
-		{
-			if (param.State == ParameterState.Incomplete)
-			{
-				return;
-			}
-			ConditionDetail.Condition cond = param.State == ParameterState.Complete ?
-				ConditionDetail.Condition.PARAMETER_COMPLETED :
-				ConditionDetail.Condition.PARAMETER_FAILED;
+        protected override void OnParameterStateChange(ContractParameter param)
+        {
+            if (param.State == ParameterState.Incomplete)
+            {
+                return;
+            }
+            ConditionDetail.Condition cond = param.State == ParameterState.Complete ?
+                ConditionDetail.Condition.PARAMETER_COMPLETED :
+                ConditionDetail.Condition.PARAMETER_FAILED;
 
-			LoggingUtil.LogDebug(this, "OnParameterStateChange() Triggered on " + param.ID + ":" + param.State);
-			foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == cond && cd.parameter == param.ID))
-				CreateVessels();
-		}
+            LoggingUtil.LogDebug(this, "OnParameterStateChange() Triggered on " + param.ID + ":" + param.State);
+            foreach (ConditionDetail cd in conditions.Where(cd => cd.condition == cond && cd.parameter == param.ID))
+                CreateVessels();
+        }
 
-		protected override void OnCancelled()
+        protected override void OnCancelled()
         {
             RemoveVessels();
         }
@@ -885,7 +892,7 @@ namespace ContractConfigurator.Behaviour
 
         protected override void OnGenerateFailed()
         {
-			RemoveVessels();
+            RemoveVessels();
         }
 
         protected override void OnOfferExpired()
@@ -900,9 +907,9 @@ namespace ContractConfigurator.Behaviour
 
         private void RemoveVessels()
         {
-			foreach (VesselData vd in vessels)
+            foreach (VesselData vd in vessels)
             {
-				Vessel vessel = FlightGlobals.Vessels.Find(v => v != null && v.id == vd.id);
+                Vessel vessel = FlightGlobals.Vessels.Find(v => v != null && v.id == vd.id);
                 if (vessel != null)
                 {
                     vessel.state = Vessel.State.DEAD;

--- a/source/ContractConfigurator/BehaviourFactory/SpawnVesselFactory.cs
+++ b/source/ContractConfigurator/BehaviourFactory/SpawnVesselFactory.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿using ContractConfigurator;
+using ContractConfigurator.ExpressionParser;
+using KerKonConConExt;
+using KSP;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
-using KSP;
-using ContractConfigurator;
 
 namespace ContractConfigurator.Behaviour
 {
@@ -13,22 +15,49 @@ namespace ContractConfigurator.Behaviour
     /// </summary>
     public class SpawnVesselFactory : BehaviourFactory
     {
-        SpawnVessel spawnVessel;
-
-        public override bool Load(ConfigNode configNode)
+		protected List<SpawnVessel.ConditionDetail> conditions = new List<SpawnVessel.ConditionDetail>();
+		protected SpawnVessel spawnVessel;
+		public override bool Load(ConfigNode configNode)
         {
             // Load base class
             bool valid = base.Load(configNode);
 
-            // Call SpawnKerbal for load behaviour
-            spawnVessel = SpawnVessel.Create(configNode, this);
+			int index = 0;
+			foreach (ConfigNode child in ConfigNodeUtil.GetChildNodes(configNode, "CONDITION"))
+			{
+				DataNode childDataNode = new DataNode("CONDITION_" + index++, dataNode, this);
+				try
+				{
+					ConfigNodeUtil.SetCurrentDataNode(childDataNode);
+					SpawnVessel.ConditionDetail cd = new SpawnVessel.ConditionDetail();
+					valid &= ConfigNodeUtil.ParseValue<SpawnVessel.ConditionDetail.Condition>(child, "condition", x => cd.condition = x, this);
+					valid &= ConfigNodeUtil.ParseValue<string>(child, "parameter", x => cd.parameter = x, this, "", x => ValidateMandatoryParameter(x, cd.condition));
+					conditions.Add(cd);
+				}
+				finally
+				{
+					ConfigNodeUtil.SetCurrentDataNode(dataNode);
+				}
+			}
+
+			// Call SpawnKerbal for load behaviour
+			spawnVessel = SpawnVessel.Create(configNode, this);
 
             return valid && spawnVessel != null;
         }
 
-        public override ContractBehaviour Generate(ConfiguredContract contract)
+		protected bool ValidateMandatoryParameter(string parameter, SpawnVessel.ConditionDetail.Condition condition)
+		{
+			if (parameter == null && (condition == SpawnVessel.ConditionDetail.Condition.PARAMETER_COMPLETED ||
+				condition == SpawnVessel.ConditionDetail.Condition.PARAMETER_FAILED))
+			{
+				throw new ArgumentException("Required if condition is PARAMETER_COMPLETED or PARAMETER_FAILED.");
+			}
+			return true;
+		}
+		public override ContractBehaviour Generate(ConfiguredContract contract)
         {
-            return new SpawnVessel(spawnVessel);
+            return new SpawnVessel(conditions, spawnVessel);
         }
     }
 }

--- a/source/ContractConfigurator/BehaviourFactory/SpawnVesselFactory.cs
+++ b/source/ContractConfigurator/BehaviourFactory/SpawnVesselFactory.cs
@@ -16,31 +16,32 @@ namespace ContractConfigurator.Behaviour
     {
         protected List<SpawnVessel.ConditionDetail> conditions = new List<SpawnVessel.ConditionDetail>();
         protected SpawnVessel spawnVessel;
+
         public override bool Load(ConfigNode configNode)
         {
             // Load base class
             bool valid = base.Load(configNode);
 
-        int index = 0;
-        foreach (ConfigNode child in ConfigNodeUtil.GetChildNodes(configNode, "CONDITION"))
-        {
-            DataNode childDataNode = new DataNode("CONDITION_" + index++, dataNode, this);
-            try
+            int index = 0;
+            foreach (ConfigNode child in ConfigNodeUtil.GetChildNodes(configNode, "CONDITION"))
             {
-                ConfigNodeUtil.SetCurrentDataNode(childDataNode);
-                SpawnVessel.ConditionDetail cd = new SpawnVessel.ConditionDetail();
-                valid &= ConfigNodeUtil.ParseValue<SpawnVessel.ConditionDetail.Condition>(child, "condition", x => cd.condition = x, this);
-                valid &= ConfigNodeUtil.ParseValue<string>(child, "parameter", x => cd.parameter = x, this, "", x => ValidateMandatoryParameter(x, cd.condition));
-                conditions.Add(cd);
+                DataNode childDataNode = new DataNode("CONDITION_" + index++, dataNode, this);
+                try
+                {
+                    ConfigNodeUtil.SetCurrentDataNode(childDataNode);
+                    SpawnVessel.ConditionDetail cd = new SpawnVessel.ConditionDetail();
+                    valid &= ConfigNodeUtil.ParseValue<SpawnVessel.ConditionDetail.Condition>(child, "condition", x => cd.condition = x, this);
+                    valid &= ConfigNodeUtil.ParseValue<string>(child, "parameter", x => cd.parameter = x, this, "", x => ValidateMandatoryParameter(x, cd.condition));
+                    conditions.Add(cd);
+                }
+                finally
+                {
+                    ConfigNodeUtil.SetCurrentDataNode(dataNode);
+                }
             }
-            finally
-            {
-                ConfigNodeUtil.SetCurrentDataNode(dataNode);
-            }
-        }
 
-        // Call SpawnKerbal for load behaviour
-        spawnVessel = SpawnVessel.Create(configNode, this);
+            // Call SpawnKerbal for load behaviour
+            spawnVessel = SpawnVessel.Create(configNode, this);
 
             return valid && spawnVessel != null;
         }
@@ -54,6 +55,7 @@ namespace ContractConfigurator.Behaviour
             }
             return true;
         }
+
         public override ContractBehaviour Generate(ConfiguredContract contract)
         {
             return new SpawnVessel(conditions, spawnVessel);

--- a/source/ContractConfigurator/BehaviourFactory/SpawnVesselFactory.cs
+++ b/source/ContractConfigurator/BehaviourFactory/SpawnVesselFactory.cs
@@ -1,6 +1,5 @@
 ﻿using ContractConfigurator;
 using ContractConfigurator.ExpressionParser;
-using KerKonConConExt;
 using KSP;
 using System;
 using System.Collections.Generic;

--- a/source/ContractConfigurator/BehaviourFactory/SpawnVesselFactory.cs
+++ b/source/ContractConfigurator/BehaviourFactory/SpawnVesselFactory.cs
@@ -15,47 +15,47 @@ namespace ContractConfigurator.Behaviour
     /// </summary>
     public class SpawnVesselFactory : BehaviourFactory
     {
-		protected List<SpawnVessel.ConditionDetail> conditions = new List<SpawnVessel.ConditionDetail>();
-		protected SpawnVessel spawnVessel;
-		public override bool Load(ConfigNode configNode)
+        protected List<SpawnVessel.ConditionDetail> conditions = new List<SpawnVessel.ConditionDetail>();
+        protected SpawnVessel spawnVessel;
+        public override bool Load(ConfigNode configNode)
         {
             // Load base class
             bool valid = base.Load(configNode);
 
-			int index = 0;
-			foreach (ConfigNode child in ConfigNodeUtil.GetChildNodes(configNode, "CONDITION"))
-			{
-				DataNode childDataNode = new DataNode("CONDITION_" + index++, dataNode, this);
-				try
-				{
-					ConfigNodeUtil.SetCurrentDataNode(childDataNode);
-					SpawnVessel.ConditionDetail cd = new SpawnVessel.ConditionDetail();
-					valid &= ConfigNodeUtil.ParseValue<SpawnVessel.ConditionDetail.Condition>(child, "condition", x => cd.condition = x, this);
-					valid &= ConfigNodeUtil.ParseValue<string>(child, "parameter", x => cd.parameter = x, this, "", x => ValidateMandatoryParameter(x, cd.condition));
-					conditions.Add(cd);
-				}
-				finally
-				{
-					ConfigNodeUtil.SetCurrentDataNode(dataNode);
-				}
-			}
+        int index = 0;
+        foreach (ConfigNode child in ConfigNodeUtil.GetChildNodes(configNode, "CONDITION"))
+        {
+            DataNode childDataNode = new DataNode("CONDITION_" + index++, dataNode, this);
+            try
+            {
+                ConfigNodeUtil.SetCurrentDataNode(childDataNode);
+                SpawnVessel.ConditionDetail cd = new SpawnVessel.ConditionDetail();
+                valid &= ConfigNodeUtil.ParseValue<SpawnVessel.ConditionDetail.Condition>(child, "condition", x => cd.condition = x, this);
+                valid &= ConfigNodeUtil.ParseValue<string>(child, "parameter", x => cd.parameter = x, this, "", x => ValidateMandatoryParameter(x, cd.condition));
+                conditions.Add(cd);
+            }
+            finally
+            {
+                ConfigNodeUtil.SetCurrentDataNode(dataNode);
+            }
+        }
 
-			// Call SpawnKerbal for load behaviour
-			spawnVessel = SpawnVessel.Create(configNode, this);
+        // Call SpawnKerbal for load behaviour
+        spawnVessel = SpawnVessel.Create(configNode, this);
 
             return valid && spawnVessel != null;
         }
 
-		protected bool ValidateMandatoryParameter(string parameter, SpawnVessel.ConditionDetail.Condition condition)
-		{
-			if (parameter == null && (condition == SpawnVessel.ConditionDetail.Condition.PARAMETER_COMPLETED ||
-				condition == SpawnVessel.ConditionDetail.Condition.PARAMETER_FAILED))
-			{
-				throw new ArgumentException("Required if condition is PARAMETER_COMPLETED or PARAMETER_FAILED.");
-			}
-			return true;
-		}
-		public override ContractBehaviour Generate(ConfiguredContract contract)
+        protected bool ValidateMandatoryParameter(string parameter, SpawnVessel.ConditionDetail.Condition condition)
+        {
+            if (parameter == null && (condition == SpawnVessel.ConditionDetail.Condition.PARAMETER_COMPLETED ||
+                condition == SpawnVessel.ConditionDetail.Condition.PARAMETER_FAILED))
+            {
+                throw new ArgumentException("Required if condition is PARAMETER_COMPLETED or PARAMETER_FAILED.");
+            }
+            return true;
+        }
+        public override ContractBehaviour Generate(ConfiguredContract contract)
         {
             return new SpawnVessel(conditions, spawnVessel);
         }


### PR DESCRIPTION
Added Conditions to the SpawnVessel Behavior to include CONTRACT_ACCEPTED, CONTRACT_FAILED, CONTRACT_COMPLETED, PARAMETER_FAILED, PARAMETER_COMPLETED.

Backward compatible with existing contracts that do not have the Conditions node. 
deferVesselCreation is deprecated and ignored.  No longer an issue in 1.12.5 
Added switchtoTrackingStation boolean to account for some vessels that will fail to spawn if in the Flight scene and using certain part modules with background processing.  (i.e. solar panels with Kerbalism).  
switchtoTrackingStation will change the scene to the Tracking Station if True.  False by default.

Tested using many, many craft files and situations.  Existing behaviour is preserved for full backward compatibility (CONTRACT_ACCEPTED).  
Here are some example Behaviour configs.  I also tested successfully for CONTRACT_FAILED and PARAMETER_FAILED.
```
BEHAVIOUR
	{
		name = SpawnHermes
		type = SpawnVessel
		deferVesselCreation = true
		VESSEL
		{
			name = Hermes
			craftURL = z/Ships/Hermes.craft
			targetBody = Mars
			owned = true
			ORBIT
			{
				SMA = 10087210.02276366
				ECC = 0.453903703469826
				INC = 0
				LPE = 177.374241304393
				LAN = 132.368654929355
				MNA = 3.25024734189098
				EPH = UniversalTime()
				REF = 1
			}
            CREW
            {
                count = 3
            }
		}
	}

	BEHAVIOUR
	{
		name = SpawnTest
		type = SpawnVessel
		VESSEL
		{
			name = TestCraft
			craftURL = z/Ships/Test.craft
			targetBody = Mars
			owned = true
			lat = -1.096992729723051
			lon = 1.425467968966
		}
		CONDITION 
		{
			condition = PARAMETER_COMPLETED
			parameter = kOSparam11
		}
	}

	BEHAVIOUR
	{
		name = SpawnPathfinder
		type = SpawnVessel
		switchtoTrackingStation = true
		VESSEL
		{
			name = PathfinderCraftSpawn
			craftURL = z/Ships/PathfinderProbe.craft
			targetBody = Mars
			owned = true
			lat = -0.096992729723051
			lon = 0.425467968966
		}
		CONDITION 
		{
			condition = CONTRACT_COMPLETED
		}
	}
```
	

- Fixed crew spawning a random crewmember, if they already exists.  Now it will spawn that available crewmember if possible.
- Also, gender property was broken and ignored.  Fixed.