### PR TITLE
Fix string expression parsing for non-English contract text

### DIFF
--- a/source/ContractConfigurator/ExpressionParser/ExpressionParser.cs
+++ b/source/ContractConfigurator/ExpressionParser/ExpressionParser.cs
@@ -1353,7 +1353,7 @@ namespace ContractConfigurator.ExpressionParser
 
         public Token ParseIdentifier()
         {
-            Match m = Regex.Match(expression, @"([A-Za-z][\w\d]*).*");
+            Match m = Regex.Match(expression, @"([A-Za-z][A-Za-z0-9_]*).*");
             string identifier = m.Groups[1].Value;
             expression = (expression.Length > identifier.Length ? expression.Substring(identifier.Length) : "");
 
@@ -1365,7 +1365,7 @@ namespace ContractConfigurator.ExpressionParser
 
         public Token ParseSpecialIdentifier()
         {
-            Match m = Regex.Match(expression, @"^@(/?(?>([A-Za-z][\w\d]*|\.\.)/)*[A-Za-z][\w\d:]*).*");
+            Match m = Regex.Match(expression, @"^@(/?(?>(?:[A-Za-z][A-Za-z0-9_]*|\.\.)/)*[A-Za-z][A-Za-z0-9_]*(?::[A-Za-z][A-Za-z0-9_]*)*).*");
             string identifier = m.Groups[1].Value;
             expression = (expression.Length > identifier.Length + 1 ? expression.Substring(identifier.Length + 1) : "");
 
@@ -1374,7 +1374,7 @@ namespace ContractConfigurator.ExpressionParser
 
         public Token ParseDataStoreIdentifier()
         {
-            Match m = Regex.Match(expression, @"^\$(/?(?>([A-Za-z][\w\d]*|\.\.)/)*[A-Za-z][\w\d:]*).*");
+            Match m = Regex.Match(expression, @"^\$(/?(?>(?:[A-Za-z][A-Za-z0-9_]*|\.\.)/)*[A-Za-z][A-Za-z0-9_]*(?::[A-Za-z][A-Za-z0-9_]*)*).*");
             string identifier = m.Groups[1].Value;
             expression = (expression.Length > identifier.Length + 1 ? expression.Substring(identifier.Length + 1) : "");
 

--- a/source/ContractConfigurator/ExpressionParser/Parsers/SimpleTypes/ListExpressionParser.cs
+++ b/source/ContractConfigurator/ExpressionParser/Parsers/SimpleTypes/ListExpressionParser.cs
@@ -230,7 +230,7 @@ namespace ContractConfigurator.ExpressionParser
                 ParseToken("(");
 
                 // Get the identifier for the object
-                Match m = Regex.Match(expression, @"([A-Za-z][\w\d]*)[\s]*=>[\s]*(.*)");
+                Match m = Regex.Match(expression, @"([A-Za-z][A-Za-z0-9_]*)[\s]*=>[\s]*(.*)");
                 string identifier = m.Groups[1].Value;
                 expression = (string.IsNullOrEmpty(identifier) ? expression : m.Groups[2].Value);
 

--- a/source/ContractConfigurator/ExpressionParser/Parsers/SimpleTypes/StringExpressionParser.cs
+++ b/source/ContractConfigurator/ExpressionParser/Parsers/SimpleTypes/StringExpressionParser.cs
@@ -90,7 +90,7 @@ namespace ContractConfigurator.ExpressionParser
 
                     value = (string)(object)result ?? "";
                 }
-                else if (token != null && token.tokenType == TokenType.FUNCTION)
+                else
                 {
                     // Check for an immediate function call 
                     Match m = Regex.Match(expression, @"^[A-Za-z][A-Za-z0-9_]*\(");

--- a/source/ContractConfigurator/ExpressionParser/Parsers/SimpleTypes/StringExpressionParser.cs
+++ b/source/ContractConfigurator/ExpressionParser/Parsers/SimpleTypes/StringExpressionParser.cs
@@ -93,12 +93,11 @@ namespace ContractConfigurator.ExpressionParser
                 else if (token != null && token.tokenType == TokenType.FUNCTION)
                 {
                     // Check for an immediate function call 
-                    // Match m = Regex.Match(expression, @"^\w[\w\d]*\(");
-                    // if (m.Success)
-                    // {
-                    //     return base.ParseStatement<TResult>();
-                    // }
-                    return base.ParseStatement<TResult>();
+                    Match m = Regex.Match(expression, @"^[A-Za-z][A-Za-z0-9_]*\(");
+                    if (m.Success)
+                    {
+                        return base.ParseStatement<TResult>();
+                    }
                 }
 
                 while (expression.Length > 0)

--- a/source/ContractConfigurator/ExpressionParser/Parsers/SimpleTypes/StringExpressionParser.cs
+++ b/source/ContractConfigurator/ExpressionParser/Parsers/SimpleTypes/StringExpressionParser.cs
@@ -90,14 +90,15 @@ namespace ContractConfigurator.ExpressionParser
 
                     value = (string)(object)result ?? "";
                 }
-                else
+                else if (token != null && token.tokenType == TokenType.FUNCTION)
                 {
                     // Check for an immediate function call 
-                    Match m = Regex.Match(expression, @"^\w[\w\d]*\(");
-                    if (m.Success)
-                    {
-                        return base.ParseStatement<TResult>();
-                    }
+                    // Match m = Regex.Match(expression, @"^\w[\w\d]*\(");
+                    // if (m.Success)
+                    // {
+                    //     return base.ParseStatement<TResult>();
+                    // }
+                    return base.ParseStatement<TResult>();
                 }
 
                 while (expression.Length > 0)
@@ -110,7 +111,7 @@ namespace ContractConfigurator.ExpressionParser
                     int dataStoreIdentifierIndex = m.Success ? m.Index : -1;
 
                     // Look for function calls
-                    m = Regex.Match(expression, @"(\A|\s)\w[\w\d]*\(");
+                    m = Regex.Match(expression, @"(\A|\s)[A-Za-z][A-Za-z0-9_]*\(");
                     int functionIndex = m == Match.Empty ? -1 : m.Index;
 
                     // Look for an end quote


### PR DESCRIPTION
This PR fixed a parsing issue where translated contract text could be misinterpreted as expression syntax.

In particular, non-English text in string fields such as title, description, synopsis, notes, and completedMessage could be incorrectly treated as function names or as part of an @... identifier.

`StringExpressionParser` and related parser code were using regex patterns based on `\w` in a few places.

In .NET, `\w` matches Unicode, not just ASCII. That means translated text such as Chinese could accidentally match parser syntax that is intended to recognize identifiers and function calls

For example, strings like:

```cfg
title = 发射@/targetBody1空间站！
```
could be parsed as though `@/targetBody1空间站` were a single `@xxx` identifier, instead of `@/targetBody1` followed by plain text.

Likewise, a string such as:

```cfg
title = 安装部件(可选)
```
could be treated as though it began with a function call, because the old `\w`-based matching considered the leading Chinese text to be a valid identifier.

After changes, the following works as expected:

```cfg
title = 发射@/targetBody1空间站！
```

where:

`发射` and `空间站！` remain plain text,
`@/targetBody1` is still parsed normally.