### PR TITLE
Prevent KSP from needlessly generating contracts

### DIFF
--- a/source/ContractConfigurator/ContractConfigurator.csproj
+++ b/source/ContractConfigurator/ContractConfigurator.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Behaviour\UnlockPart.cs" />
     <Compile Include="Behaviour\UnlockTech.cs" />
     <Compile Include="HarmonyPatcher.cs" />
+    <Compile Include="Harmony\Contract.cs" />
     <Compile Include="Harmony\Kerbal.cs" />
     <Compile Include="Harmony\ContractSystem.cs" />
     <Compile Include="ScenarioModules\ScienceReporter.cs" />

--- a/source/ContractConfigurator/Harmony/Contract.cs
+++ b/source/ContractConfigurator/Harmony/Contract.cs
@@ -1,0 +1,33 @@
+﻿using Contracts;
+using HarmonyLib;
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+
+namespace ContractConfigurator.Harmony
+{
+    [HarmonyPatch(typeof(Contract))]
+    internal class PatchContract
+    {
+        /// <summary>
+        /// KSP's ContractSystem calls Contract.Generate() with State.Generated when filling the offered contracts.
+        /// ConfiguredContract.Generate() always returns false for these calls (contractType is unset on fresh instances) so each attempt is a wasted allocation.
+        /// Short-circuit here before Activator.CreateInstance is reached. The pre-loader uses State.Withdrawn, which is allowed through.
+        /// </summary>
+        /// <param name="__result"></param>
+        /// <param name="contractType"></param>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch("Generate", new Type[] { typeof(Type), typeof(Contract.ContractPrestige), typeof(int), typeof(Contract.State) })]
+        internal static bool Prefix_Generate(ref Contract __result, Type contractType, Contract.State state)
+        {
+            if (contractType == typeof(ConfiguredContract) && state == Contract.State.Generated)
+            {
+                __result = null;
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/source/ContractConfigurator/Harmony/ContractSystem.cs
+++ b/source/ContractConfigurator/Harmony/ContractSystem.cs
@@ -58,6 +58,22 @@ namespace ContractConfigurator.Harmony
             }
         }
 
+        /// <summary>
+        /// Skip weighted random selection when ConfiguredContract is the only registered contract type.
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch("WeightedContractChoice")]
+        internal static bool Prefix_WeightedContractChoice(ref Type __result)
+        {
+            if (ContractSystem.ContractTypes?.Count == 1 &&
+                ContractSystem.ContractTypes[0] == typeof(ConfiguredContract))
+            {
+                __result = typeof(ConfiguredContract);
+                return false;
+            }
+            return true;
+        }
+
         private class PostfixEnumerator : IEnumerable
         {
             public IEnumerator enumerator;

--- a/source/ContractConfigurator/Harmony/ContractSystem.cs
+++ b/source/ContractConfigurator/Harmony/ContractSystem.cs
@@ -41,6 +41,23 @@ namespace ContractConfigurator.Harmony
             }
         }
 
+        /// <summary>
+        /// Make KSP count pre-loaded CC contracts toward the offered-contract quota
+        /// </summary>
+        /// <param name="__result"></param>
+        /// <param name="difficulty"></param>
+        [HarmonyPostfix]
+        [HarmonyPatch("CountContracts")]
+        internal static void Postfix_CountContracts(ref int __result, Contract.ContractPrestige difficulty)
+        {
+            if (ContractPreLoader.Instance == null) return;
+            foreach (ConfiguredContract c in ContractPreLoader.Instance.PendingContracts())
+            {
+                if (c.Prestige == difficulty)
+                    __result++;
+            }
+        }
+
         private class PostfixEnumerator : IEnumerable
         {
             public IEnumerator enumerator;

--- a/source/ContractConfigurator/ScenarioModules/ContractPreLoader.cs
+++ b/source/ContractConfigurator/ScenarioModules/ContractPreLoader.cs
@@ -29,7 +29,7 @@ namespace ContractConfigurator
         private static System.Random rand = new System.Random();
         private static int nextContractGroup = rand.Next();
 
-        private List<ConfiguredContract> contracts = new List<ConfiguredContract>();
+        private readonly List<ConfiguredContract> contracts = new List<ConfiguredContract>();
 
         private string lastKey = null;
         private double lastGenerationFailure;
@@ -376,7 +376,7 @@ namespace ContractConfigurator
         {
             try
             {
-                foreach (ConfiguredContract contract in contracts.Where(c => c.ContractState == Contract.State.Offered))
+                foreach (ConfiguredContract contract in contracts)
                 {
                     ConfigNode child = new ConfigNode("CONTRACT");
                     node.AddNode(child);
@@ -436,9 +436,15 @@ namespace ContractConfigurator
             }
         }
 
-        public IEnumerable<ConfiguredContract> PendingContracts()
+        /// <summary>
+        /// Contracts that have been generated but not yet accepted. Not all of may be presented to the player.
+        /// Do not edit the returned collection directly.
+        /// </summary>
+        /// <returns></returns>
+        public List<ConfiguredContract> PendingContracts()
         {
-            return contracts.Where(c => c.ContractState == Contract.State.Offered);
+            // contracts only ever holds State.Offered contracts
+            return contracts;
         }
     }
 }


### PR DESCRIPTION
Will lower allocations ~~by an order of magnitude~~ to 0 if all stock contracts are disabled and all contracts are handled through CC. Otherwise the effect will be smaller.