### PR TITLE
Fix per-prestige contract limits not showing up in UI sometimes

### DIFF
--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -805,6 +805,9 @@ namespace ContractConfigurator.Util
 
         public void OnClickAll(bool selected)
         {
+            // Update the contract counts even if not selected (KSP overrides it otherwise)
+            UpdateContractCounts();
+            
             if (!selected)
             {
                 return;
@@ -832,9 +835,6 @@ namespace ContractConfigurator.Util
 
             HighLogic.CurrentGame.Parameters.CustomParams<ContractConfiguratorParameters>().lastMCButton =
                 ContractConfiguratorParameters.MissionControlButton.All;
-
-            // Update the contract counts
-            UpdateContractCounts();
         }
 
         public void OnClickActive(bool selected)


### PR DESCRIPTION
This PR fixes the bug that I mentioned in https://github.com/KSP-RO/RP-1/pull/2776#issuecomment-4416150904, where the contract limit text doesn't appear sometimes. Now they always appear.
<img width="1322" height="423" alt="image" src="https://github.com/user-attachments/assets/2c0764ab-4444-4af7-a311-7b8883fdee24" />