### PR TITLE
Replace partName with partInfo.name

### DIFF
--- a/source/ContractConfigurator/Behaviour/SpawnKerbal.cs
+++ b/source/ContractConfigurator/Behaviour/SpawnKerbal.cs
@@ -507,7 +507,7 @@ namespace ContractConfigurator.Behaviour
                                     if (p.protoModuleCrew.Contains(kerbal.kerbal.pcm))
                                     {
                                         // Command seats
-                                        if (p.partName == "kerbalEVA")
+                                        if (p.partInfo.name == "kerbalEVA")
                                         {
                                             vessel.parts.Remove(p);
                                         }

--- a/source/ContractConfigurator/ExpressionParser/Wrappers/Kerbal.cs
+++ b/source/ContractConfigurator/ExpressionParser/Wrappers/Kerbal.cs
@@ -282,7 +282,7 @@ namespace ContractConfigurator
                             if (p.protoModuleCrew.Contains(pcm))
                             {
                                 // Command seats
-                                if (p.partName == "kerbalEVA")
+                                if (p.partInfo.name == "kerbalEVA")
                                 {
                                     vessel.parts.Remove(p);
                                 }


### PR DESCRIPTION
Fix https://github.com/KSP-RO/ContractConfigurator/issues/54

JonnyOThan redirected me to this working instead of partName awhile back. I did not test this in-game (but it compiles obviously)

In this codebase there's still some instances of ProtoPartSnapshot.partName, unsure if those face the same problem or if they actually return the part name.

Proof of partInfo.name working compared to partName:
<img width="686" height="436" alt="image" src="https://github.com/user-attachments/assets/1ca2de40-b9ca-4543-8940-5a78bf15129b" />

<img width="1137" height="248" alt="image" src="https://github.com/user-attachments/assets/16da209f-76ab-410a-b463-22d0870aa0f2" />
