### PR TITLE
Do not show contract limit when limit is at maxValue, add FormatContractText() method

### DIFF
--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -1297,6 +1297,26 @@ namespace ContractConfigurator.Util
             }
         }
 
+        private void FormatContractText(ref string output, int starCount, string title, int current, int max, string starSpacing, string titleSpacing, bool addNewLine)
+        {
+            string stars = string.Concat(Enumerable.Repeat("<sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1>", starCount));
+
+            string text;
+
+            if (max == int.MaxValue)
+            {
+                text = "{2}";
+            }
+            else
+            {
+                text = current >= max ? "<color=#f97306>{2}  [{1}: {3}]</color>" : "{2}  [{1}: {3}]";
+            }
+
+            text = addNewLine ? text + "\n" : text;
+
+            output += StringBuilderCache.Format($"<b><color=#f4ee21>{stars}{starSpacing}</color><color=#DB8310>{{0}}{titleSpacing}</color></b>{text}", Localizer.Format(title), Localizer.Format("#cc.mcui.max"), current, max);
+        }
+
         protected void UpdateContractCounts()
         {
             int activeCount = ContractSystem.Instance.GetActiveContractCount();
@@ -1326,11 +1346,12 @@ namespace ContractConfigurator.Util
             int exceptionalMax = Math.Min(ContractConfigurator.ContractLimit(Contract.ContractPrestige.Exceptional), maxActive);
 
             string output = "";
-            output += StringBuilderCache.Format("<b><color=#f4ee21><sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1>\t\t</color><color=#DB8310>{0}\t\t</color></b>" + (trivialCount >= trivialMax ? "<color=#f97306>{2}  [{1}: {3}]</color>\n" : "{2}  [{1}: {3}]\n"), Localizer.Format("#cc.mcui.title.trivial"), Localizer.Format("#cc.mcui.max"), trivialCount, trivialMax);
-            output += StringBuilderCache.Format("<b><color=#f4ee21><sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1><sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1>\t\t</color><color=#DB8310>{0}\t</color></b>" + (significantCount >= significantMax ? "<color=#f97306>{2}  [{1}: {3}]</color>\n" : "{2}  [{1}: {3}]\n"), Localizer.Format("#cc.mcui.title.significant"), Localizer.Format("#cc.mcui.max"), significantCount, significantMax);
-            output += StringBuilderCache.Format("<b><color=#f4ee21><sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1><sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1><sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1>\t</color><color=#DB8310>{0}\t</color></b>" + (exceptionalCount >= exceptionalMax ? "<color=#f97306>{2}  [{1}: {3}]</color>\n" : "{2}  [{1}: {3}]\n"), Localizer.Format("#cc.mcui.title.exceptional"), Localizer.Format("#cc.mcui.max"), exceptionalCount, exceptionalMax);
-            output += StringBuilderCache.Format("<b>\t\t<color=#DB8310>{0}\t\t</color></b>" + (maxActive == int.MaxValue ? "{2}" : activeCount >= maxActive ? "<color=#f97306>{2}  [{1}: {3}]</color>" : "{2}  [{1}: {3}]"), Localizer.Format("#cc.mcui.title.allActive"), Localizer.Format("#cc.mcui.max"), activeCount, maxActive);
-            MissionControl.Instance.textMCStats.text = output; MissionControl.Instance.textMCStats.text = output;
+            FormatContractText(ref output, 1, "#cc.mcui.title.trivial", trivialCount, trivialMax, "\t\t", "\t\t", true);
+            FormatContractText(ref output, 2, "#cc.mcui.title.significant", significantCount, significantMax, "\t\t", "\t", true);
+            FormatContractText(ref output, 3, "#cc.mcui.title.exceptional", exceptionalCount, exceptionalMax, "\t", "\t", true);
+            FormatContractText(ref output, 0, "#cc.mcui.title.allActive", activeCount, maxActive, "\t\t", "\t\t", false);
+
+            MissionControl.Instance.textMCStats.text = output;
         }
 
         protected void OnDeselectContract(UIRadioButton button, UIRadioButton.CallType callType, PointerEventData data)

--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -1,10 +1,4 @@
-﻿using ContractConfigurator.Parameters;
-using Contracts;
-using Contracts.Agents;
-using KSP.Localization;
-using KSP.UI;
-using KSP.UI.Screens;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -13,6 +7,12 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+using Contracts;
+using Contracts.Agents;
+using KSP.UI;
+using KSP.UI.Screens;
+using KSP.Localization;
+using ContractConfigurator.Parameters;
 
 namespace ContractConfigurator.Util
 {

--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -1305,16 +1305,16 @@ namespace ContractConfigurator.Util
 
             if (max == int.MaxValue)
             {
-                text = "{2}";
+                text = "{5}";
             }
             else
             {
-                text = current >= max ? "<color=#f97306>{2}  [{1}: {3}]</color>" : "{2}  [{1}: {3}]";
+                text = current >= max ? "<color=#f97306>{5}  [{4}: {6}]</color>" : "{5}  [{4}: {6}]";
             }
 
             text = addNewLine ? text + "\n" : text;
 
-            output += StringBuilderCache.Format($"<b><color=#f4ee21>{stars}{starSpacing}</color><color=#DB8310>{{0}}{titleSpacing}</color></b>{text}", Localizer.Format(title), Localizer.Format("#cc.mcui.max"), current, max);
+            output += StringBuilderCache.Format("<b><color=#f4ee21>{0}{1}</color><color=#DB8310>{2}{3}</color></b>" + text, stars, starSpacing, Localizer.Format(title), titleSpacing, Localizer.Format("#cc.mcui.max"), current, max);
         }
 
         protected void UpdateContractCounts()

--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿using ContractConfigurator.Parameters;
+using Contracts;
+using Contracts.Agents;
+using KSP.Localization;
+using KSP.UI;
+using KSP.UI.Screens;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -7,12 +13,6 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
-using Contracts;
-using Contracts.Agents;
-using KSP.UI;
-using KSP.UI.Screens;
-using KSP.Localization;
-using ContractConfigurator.Parameters;
 
 namespace ContractConfigurator.Util
 {
@@ -1297,24 +1297,37 @@ namespace ContractConfigurator.Util
             }
         }
 
-        private void FormatContractCounts(ref string output, int starCount, string title, int current, int max, string starSpacing, string titleSpacing, bool addNewLine)
+        private void FormatContractCounts(StringBuilder sb, int starCount, string title, int current, int max, string starSpacing, string titleSpacing, bool addNewLine)
         {
-            string stars = string.Concat(Enumerable.Repeat("<sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1>", starCount));
+            sb.Append("<b><color=#f4ee21>");
 
-            string text;
+            for (int i = 0; i < starCount; i++)
+            {
+                sb.Append("<sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1>");
+            }
+
+            sb.AppendFormat("{0}</color><color=#DB8310>{1}{2}</color></b>", starSpacing, Localizer.Format(title), titleSpacing);
 
             if (max == int.MaxValue)
             {
-                text = "{5}{7}";
+                sb.AppendFormat("{0}", current);
             }
             else
             {
-                text = current >= max ? "<color=#f97306>{5}  [{4}: {6}]</color>{7}" : "{5}  [{4}: {6}]{7}";
+                if (current >= max)
+                {
+                    sb.AppendFormat("<color=#f97306>{0}  [{1}: {2}]</color>", current, Localizer.Format("#cc.mcui.max"), max);
+                }
+                else
+                {
+                    sb.AppendFormat("{0}  [{1}: {2}]", current, Localizer.Format("#cc.mcui.max"), max);
+                }
             }
 
-            string newLine = addNewLine ? "\n" : "";
-
-            output += StringBuilderCache.Format("<b><color=#f4ee21>{0}{1}</color><color=#DB8310>{2}{3}</color></b>" + text, stars, starSpacing, Localizer.Format(title), titleSpacing, Localizer.Format("#cc.mcui.max"), current, max, newLine);
+            if (addNewLine)
+            {
+                sb.Append("\n");
+            }
         }
 
         protected void UpdateContractCounts()
@@ -1345,13 +1358,13 @@ namespace ContractConfigurator.Util
             int significantMax = Math.Min(ContractConfigurator.ContractLimit(Contract.ContractPrestige.Significant), maxActive);
             int exceptionalMax = Math.Min(ContractConfigurator.ContractLimit(Contract.ContractPrestige.Exceptional), maxActive);
 
-            string output = "";
-            FormatContractCounts(ref output, 1, "#cc.mcui.title.trivial", trivialCount, trivialMax, "\t\t", "\t\t", true);
-            FormatContractCounts(ref output, 2, "#cc.mcui.title.significant", significantCount, significantMax, "\t\t", "\t", true);
-            FormatContractCounts(ref output, 3, "#cc.mcui.title.exceptional", exceptionalCount, exceptionalMax, "\t", "\t", true);
-            FormatContractCounts(ref output, 0, "#cc.mcui.title.allActive", activeCount, maxActive, "\t\t", "\t\t", false);
+            StringBuilder sb = StringBuilderCache.Acquire();
+            FormatContractCounts(sb, 1, "#cc.mcui.title.trivial", trivialCount, trivialMax, "\t\t", "\t\t", true);
+            FormatContractCounts(sb, 2, "#cc.mcui.title.significant", significantCount, significantMax, "\t\t", "\t", true);
+            FormatContractCounts(sb, 3, "#cc.mcui.title.exceptional", exceptionalCount, exceptionalMax, "\t", "\t", true);
+            FormatContractCounts(sb, 0, "#cc.mcui.title.allActive", activeCount, maxActive, "\t\t", "\t\t", false);
 
-            MissionControl.Instance.textMCStats.text = output;
+            MissionControl.Instance.textMCStats.text = sb.ToStringAndRelease();
         }
 
         protected void OnDeselectContract(UIRadioButton button, UIRadioButton.CallType callType, PointerEventData data)

--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -1297,7 +1297,7 @@ namespace ContractConfigurator.Util
             }
         }
 
-        private void FormatContractText(ref string output, int starCount, string title, int current, int max, string starSpacing, string titleSpacing, bool addNewLine)
+        private void FormatContractCounts(ref string output, int starCount, string title, int current, int max, string starSpacing, string titleSpacing, bool addNewLine)
         {
             string stars = string.Concat(Enumerable.Repeat("<sprite=\"CurrencySpriteAsset\" name=\"Reputation\" tint=1>", starCount));
 
@@ -1346,10 +1346,10 @@ namespace ContractConfigurator.Util
             int exceptionalMax = Math.Min(ContractConfigurator.ContractLimit(Contract.ContractPrestige.Exceptional), maxActive);
 
             string output = "";
-            FormatContractText(ref output, 1, "#cc.mcui.title.trivial", trivialCount, trivialMax, "\t\t", "\t\t", true);
-            FormatContractText(ref output, 2, "#cc.mcui.title.significant", significantCount, significantMax, "\t\t", "\t", true);
-            FormatContractText(ref output, 3, "#cc.mcui.title.exceptional", exceptionalCount, exceptionalMax, "\t", "\t", true);
-            FormatContractText(ref output, 0, "#cc.mcui.title.allActive", activeCount, maxActive, "\t\t", "\t\t", false);
+            FormatContractCounts(ref output, 1, "#cc.mcui.title.trivial", trivialCount, trivialMax, "\t\t", "\t\t", true);
+            FormatContractCounts(ref output, 2, "#cc.mcui.title.significant", significantCount, significantMax, "\t\t", "\t", true);
+            FormatContractCounts(ref output, 3, "#cc.mcui.title.exceptional", exceptionalCount, exceptionalMax, "\t", "\t", true);
+            FormatContractCounts(ref output, 0, "#cc.mcui.title.allActive", activeCount, maxActive, "\t\t", "\t\t", false);
 
             MissionControl.Instance.textMCStats.text = output;
         }

--- a/source/ContractConfigurator/MissionControlUI.cs
+++ b/source/ContractConfigurator/MissionControlUI.cs
@@ -1305,16 +1305,16 @@ namespace ContractConfigurator.Util
 
             if (max == int.MaxValue)
             {
-                text = "{5}";
+                text = "{5}{7}";
             }
             else
             {
-                text = current >= max ? "<color=#f97306>{5}  [{4}: {6}]</color>" : "{5}  [{4}: {6}]";
+                text = current >= max ? "<color=#f97306>{5}  [{4}: {6}]</color>{7}" : "{5}  [{4}: {6}]{7}";
             }
 
-            text = addNewLine ? text + "\n" : text;
+            string newLine = addNewLine ? "\n" : "";
 
-            output += StringBuilderCache.Format("<b><color=#f4ee21>{0}{1}</color><color=#DB8310>{2}{3}</color></b>" + text, stars, starSpacing, Localizer.Format(title), titleSpacing, Localizer.Format("#cc.mcui.max"), current, max);
+            output += StringBuilderCache.Format("<b><color=#f4ee21>{0}{1}</color><color=#DB8310>{2}{3}</color></b>" + text, stars, starSpacing, Localizer.Format(title), titleSpacing, Localizer.Format("#cc.mcui.max"), current, max, newLine);
         }
 
         protected void UpdateContractCounts()


### PR DESCRIPTION
Bug reported by [Worcester](https://discord.com/channels/319857228905447436/1115321536807718992/1508536036144320513)

Before:
<img width="443" height="143" alt="image" src="https://github.com/user-attachments/assets/d1b1233a-0fb9-49de-8da5-e0ec39523874" />

After:
<img width="380" height="138" alt="image" src="https://github.com/user-attachments/assets/29720854-0ad3-4207-96e5-beed2e44fb3f" />

Also condensed all of this text into a method, since it was very repetitive and hard to follow.