### PR TITLE
Do not cancel active contract if prestige has changed

### DIFF
--- a/source/ContractConfigurator/ContractType.cs
+++ b/source/ContractConfigurator/ContractType.cs
@@ -756,17 +756,9 @@ namespace ContractConfigurator
                 }
 
                 // Check prestige
-                if (prestige.Count > 0 && !prestige.Contains(contract.Prestige))
+                if (prestige.Count > 0 && !prestige.Contains(contract.Prestige) && contract.ContractState != Contract.State.Active)
                 {
-                    if (prestige.Count == 1 && contract.ContractState == Contract.State.Active)
-                    {
-                        contract.Prestige = prestige.First();
-                        LoggingUtil.LogInfo(this,  "Setting prestige level to {0} for contract of type {1} ({2}).", contract.Prestige.ToString(), name, contract.Title);
-                    }
-                    else
-                    {
-                        throw new ContractRequirementException("Wrong prestige level.");
-                    }
+                    throw new ContractRequirementException("Wrong prestige level.");
                 }
 
                 // Do a Research Bodies check, if applicable

--- a/source/ContractConfigurator/ContractType.cs
+++ b/source/ContractConfigurator/ContractType.cs
@@ -758,7 +758,15 @@ namespace ContractConfigurator
                 // Check prestige
                 if (prestige.Count > 0 && !prestige.Contains(contract.Prestige))
                 {
-                    throw new ContractRequirementException("Wrong prestige level.");
+                    if (prestige.Count == 1 && contract.ContractState == Contract.State.Active)
+                    {
+                        contract.Prestige = prestige.First();
+                        LoggingUtil.LogInfo(this,  "Setting prestige level to {0} for contract of type {1} ({2}).", contract.Prestige.ToString(), name, contract.Title);
+                    }
+                    else
+                    {
+                        throw new ContractRequirementException("Wrong prestige level.");
+                    }
                 }
 
                 // Do a Research Bodies check, if applicable


### PR DESCRIPTION
Bug reported by [jimmymcgoochie](https://discord.com/channels/319857228905447436/620690446540341261/1508544921379012760) and [njits23](https://discord.com/channels/319857228905447436/620690446540341261/1508553115933343744).

An error would previously be thrown when going from RP-1 4.3.0.0 to 4.4.0.0, due to the changes in https://github.com/KSP-RO/RP-1/pull/2776. This would cancel the already active contract, so the user had to accept the contract again to use it. This is unnecessary, as the correct prestige should be known already, so we can just set the old prestige to the new prestige.

Before:
```
[LOG 17:18:56.463] [INFO] ContractConfigurator.ContractType: Cancelling contract of type XPlanesStratosphericResearch (X-Planes (Stratospheric Research)): Wrong prestige level.
[WRN 17:18:56.463] ContractConfigurator.ConfiguredContract: Removed contract 'X-Planes (Stratospheric Research)', as it no longer meets the requirements.
```

After:
```
[LOG 17:48:22.492] [INFO] ContractConfigurator.ContractType: Setting prestige level to Significant for contract of type XPlanesStratosphericResearch (X-Planes (Stratospheric Research)).
```