### PR TITLE
Remove release_status from the netkan

### DIFF
--- a/ContractConfiguratorRO.netkan
+++ b/ContractConfiguratorRO.netkan
@@ -5,7 +5,6 @@
     "name": "Contract Configurator",
     "abstract": "A config-file based solution for creating new contracts!",
     "license": "MIT",
-    "release_status": "stable",
     "author": [ "nightingale", "KSP-RO team" ],
     "$vref": "#/ckan/ksp-avc",
     "ksp_version_strict" : true,


### PR DESCRIPTION
This should allow ckan to [autofill](https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#ckangithubuserrepoasset_matchfilter_regexpversion_from_assetversion_regexp) the release status, so that it can be marked as a pre-release if it is one