### PR TITLE
Make min/maxTerrainAltitude match altimeter widget readouts

### DIFF
--- a/source/ContractConfigurator/Parameter/VesselParameter/ReachState.cs
+++ b/source/ContractConfigurator/Parameter/VesselParameter/ReachState.cs
@@ -186,7 +186,10 @@ namespace ContractConfigurator.Parameters
                     output = Localizer.Format("#cc.param.Orbit.between.meters", Localizer.GetStringByTag("#cc.param.ReachState.altitudeTerrain"), minTerrainAltitude.ToString("N0"), maxTerrainAltitude.ToString("N0"));
                 }
 
-                AddParameter(new ParameterDelegate<Vessel>(output, v => v.heightFromTerrain >= minTerrainAltitude && v.heightFromTerrain <= maxTerrainAltitude));
+                // Match the in-game altimeter (AGL): radarAltitude is derived from PQSAltitude().
+                // It is an analytic solution and does not rely on terrain colliders.
+                // Note that radarAltitude has weird behavior for bodies with below datum terrain.
+                AddParameter(new ParameterDelegate<Vessel>(output, v => v.radarAltitude >= minTerrainAltitude && v.radarAltitude <= maxTerrainAltitude));
             }
 
             // Filter for speed


### PR DESCRIPTION
Currently minTerrainAltitude/maxTerrainAltitude checks read `Vessel.heightFromTerrain`, which comes from a downward physics raycast against the terrain collider. For fast vessels (impactors, low orbits) the collider LOD can't be built under the moving ground track in time, so the raycast misses and KSP silently substitutes the vessel's sea-level altitude. The check then flickers or never passes — even though the in-game altimeter shows the craft is clearly within the desired terrain-altitude band.

This PR changes the behavior to match the stock altimeter's AGL/terrain readout (i.e it's using the `Vessel.radarAltitude` value).
There are some fundamental differences though:
* Over oceans it now measures to the water surface instead of the seabed
* Over below-datum land it under-reports true geometric distance while the craft is above the datum, then matches true distance below the datum.